### PR TITLE
Add user join/leave group endpoint in Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ More examples can be found in the [examples](examples) directory.
 | `PUT /admin/realms/{realm}/users/{userId}` | `n/a` | [Users::update()](src/Resource/Users.php) |
 | `DELETE /admin/realms/{realm}/users/{userId}` | `n/a` | [Users::delete()](src/Resource/Users.php) |
 | `GET /admin/realms/{realm}/users` | [UserCollection](src/Collection/UserCollection.php) | [Users::search()](src/Resource/Users.php) |
+| `PUT /{realm}/users/{id}/groups/{groupId}` | `n/a` | [Users::joinGroup()](src/Resource/Users.php) |
+| `DELETE /{realm}/users/{id}/groups/{groupId}` | `n/a` | [Users::leaveGroup()](src/Resource/Users.php) |
 
 ### [Root](https://www.keycloak.org/docs-api/20.0.0/rest-api/index.html#_root_resource)
 | Endpoint | Response | API |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ More examples can be found in the [examples](examples) directory.
 | `GET /admin/realms/{realm}/users` | [UserCollection](src/Collection/UserCollection.php) | [Users::search()](src/Resource/Users.php) |
 | `PUT /{realm}/users/{id}/groups/{groupId}` | `n/a` | [Users::joinGroup()](src/Resource/Users.php) |
 | `DELETE /{realm}/users/{id}/groups/{groupId}` | `n/a` | [Users::leaveGroup()](src/Resource/Users.php) |
+| `GET /{realm}/users/{id}/groups` | [GroupCollection](src/Collection/GroupCollection.php) | [Users::retrieveGroups()](src/Resource/Users.php) |
 
 ### [Root](https://www.keycloak.org/docs-api/20.0.0/rest-api/index.html#_root_resource)
 | Endpoint | Response | API |

--- a/src/Resource/Users.php
+++ b/src/Resource/Users.php
@@ -97,4 +97,34 @@ class Users extends Resource
             )
         );
     }
+
+    public function joinGroup(string $realm, string $userId, string $groupId): void
+    {
+        $this->commandExecutor->executeCommand(
+            new Command(
+                '/admin/realms/{realm}/users/{userId}/groups/{groupId}',
+                Method::PUT,
+                [
+                    'realm' => $realm,
+                    'userId' => $userId,
+                    'groupId' => $groupId,
+                ]
+            )
+        );
+    }
+
+    public function leaveGroup(string $realm, string $userId, string $groupId): void
+    {
+        $this->commandExecutor->executeCommand(
+            new Command(
+                '/admin/realms/{realm}/users/{userId}/groups/{groupId}',
+                Method::DELETE,
+                [
+                    'realm' => $realm,
+                    'userId' => $userId,
+                    'groupId' => $groupId,
+                ]
+            )
+        );
+    }
 }

--- a/src/Resource/Users.php
+++ b/src/Resource/Users.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fschmtt\Keycloak\Resource;
 
+use Fschmtt\Keycloak\Collection\GroupCollection;
 use Fschmtt\Keycloak\Collection\UserCollection;
 use Fschmtt\Keycloak\Http\Command;
 use Fschmtt\Keycloak\Http\Criteria;
@@ -124,6 +125,21 @@ class Users extends Resource
                     'userId' => $userId,
                     'groupId' => $groupId,
                 ]
+            )
+        );
+    }
+
+    public function retrieveGroups(string $realm, string $userId, ?Criteria $criteria = null): GroupCollection
+    {
+        return $this->queryExecutor->executeQuery(
+            new Query(
+                '/admin/realms/{realm}/users/{userId}/groups',
+                GroupCollection::class,
+                [
+                    'realm' => $realm,
+                    'userId' => $userId,
+                ],
+                $criteria
             )
         );
     }

--- a/tests/Unit/Resource/UsersTest.php
+++ b/tests/Unit/Resource/UsersTest.php
@@ -190,4 +190,54 @@ class UsersTest extends TestCase
 
         $users->search('test-realm', $criteria);
     }
+
+    public function testJoinGroup(): void
+    {
+        $command = new Command(
+            '/admin/realms/{realm}/users/{userId}/groups/{groupId}',
+            Method::PUT,
+            [
+                'realm' => 'test-realm',
+                'userId' => 'test-user',
+                'groupId' => 'test-group',
+            ],
+        );
+
+        $commandExecutor = $this->createMock(CommandExecutor::class);
+        $commandExecutor->expects(static::once())
+            ->method('executeCommand')
+            ->with($command);
+
+        $users = new Users(
+            $commandExecutor,
+            $this->createMock(QueryExecutor::class),
+        );
+
+        $users->joinGroup('test-realm', 'test-user', 'test-group');
+    }
+
+    public function testLeaveGroup(): void
+    {
+        $command = new Command(
+            '/admin/realms/{realm}/users/{userId}/groups/{groupId}',
+            Method::DELETE,
+            [
+                'realm' => 'test-realm',
+                'userId' => 'test-user',
+                'groupId' => 'test-group',
+            ],
+        );
+
+        $commandExecutor = $this->createMock(CommandExecutor::class);
+        $commandExecutor->expects(static::once())
+            ->method('executeCommand')
+            ->with($command);
+
+        $users = new Users(
+            $commandExecutor,
+            $this->createMock(QueryExecutor::class),
+        );
+
+        $users->joinGroup('test-realm', 'test-user', 'test-group');
+    }
 }

--- a/tests/Unit/Resource/UsersTest.php
+++ b/tests/Unit/Resource/UsersTest.php
@@ -238,6 +238,6 @@ class UsersTest extends TestCase
             $this->createMock(QueryExecutor::class),
         );
 
-        $users->joinGroup('test-realm', 'test-user', 'test-group');
+        $users->leaveGroup('test-realm', 'test-user', 'test-group');
     }
 }

--- a/tests/Unit/Resource/UsersTest.php
+++ b/tests/Unit/Resource/UsersTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fschmtt\Keycloak\Test\Unit\Resource;
 
+use Fschmtt\Keycloak\Collection\GroupCollection;
 use Fschmtt\Keycloak\Collection\UserCollection;
 use Fschmtt\Keycloak\Http\Command;
 use Fschmtt\Keycloak\Http\CommandExecutor;
@@ -11,6 +12,7 @@ use Fschmtt\Keycloak\Http\Criteria;
 use Fschmtt\Keycloak\Http\Method;
 use Fschmtt\Keycloak\Http\Query;
 use Fschmtt\Keycloak\Http\QueryExecutor;
+use Fschmtt\Keycloak\Representation\Group;
 use Fschmtt\Keycloak\Representation\User;
 use Fschmtt\Keycloak\Resource\Users;
 use PHPUnit\Framework\TestCase;
@@ -239,5 +241,38 @@ class UsersTest extends TestCase
         );
 
         $users->leaveGroup('test-realm', 'test-user', 'test-group');
+    }
+
+    public function testRetrieveGroups(): void
+    {
+        $query = new Query(
+            '/admin/realms/{realm}/users/{userId}/groups',
+            GroupCollection::class,
+            [
+                'realm' => 'test-realm',
+                'userId' => 'test-user',
+            ],
+        );
+
+        $groupCollection = new GroupCollection([
+            new Group(id: 'test-group-1'),
+            new Group(id: 'test-group-2'),
+        ]);
+
+        $queryExecutor = $this->createMock(QueryExecutor::class);
+        $queryExecutor->expects(static::once())
+            ->method('executeQuery')
+            ->with($query)
+            ->willReturn($groupCollection);
+
+        $users = new Users(
+            $this->createMock(CommandExecutor::class),
+            $queryExecutor,
+        );
+
+        static::assertSame(
+            $groupCollection,
+            $users->retrieveGroups('test-realm', 'test-user')
+        );
     }
 }


### PR DESCRIPTION
Thank you for all the great work on this library.

In my application I need to manipulate user groups by the API and was expecting to do so using the `groups` in the [UserRepresentation](https://www.keycloak.org/docs-api/19.0.1/rest-api/index.html#_userrepresentation) but unfortunately it doesn't work.

One can find discussions [here](https://keycloak.discourse.group/t/how-to-assign-multiple-groups-to-user-in-one-rest-api-call/15374) or [there](https://github.com/keycloak/keycloak/discussions/8552) about this not working on Keycloak side.

The alternative is to use the [two endpoints](https://www.keycloak.org/docs-api/19.0.1/rest-api/index.html#_joingroup) to join and leave a group, this lacks the batch feature but that's the way it is.

This pull request adds this specific feature in the Users class, I would really appreciate if you could merge it.

Comments and feedback obviously highly welcome.