### PR TITLE
Add user add/remove realm roles endpoints in Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ More examples can be found in the [examples](examples) directory.
 | `PUT /{realm}/users/{id}/groups/{groupId}` | `n/a` | [Users::joinGroup()](src/Resource/Users.php) |
 | `DELETE /{realm}/users/{id}/groups/{groupId}` | `n/a` | [Users::leaveGroup()](src/Resource/Users.php) |
 | `GET /{realm}/users/{id}/groups` | [GroupCollection](src/Collection/GroupCollection.php) | [Users::retrieveGroups()](src/Resource/Users.php) |
+| `GET /{realm}/users/{id}/role-mappings/realm` | [RoleCollection](src/Collection/RoleCollection.php) | [Users::retrieveRealmRoles()](src/Resource/Users.php) |
+| `GET /{realm}/users/{id}/role-mappings/realm/available` | [RoleCollection](src/Collection/RoleCollection.php) | [Users::retrieveAvailableRealmRoles()](src/Resource/Users.php) |
+| `POST /{realm}/users/{id}/role-mappings/realm` | `n/a` | [Users::addRealmRoles()](src/Resource/Users.php) |
+| `DELETE /{realm}/users/{id}/role-mappings/realm` | `n/a` | [Users::removeRealmRoles()](src/Resource/Users.php) |
 
 ### [Root](https://www.keycloak.org/docs-api/20.0.0/rest-api/index.html#_root_resource)
 | Endpoint | Response | API |

--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ More examples can be found in the [examples](examples) directory.
 | `POST /{realm}/users/{id}/role-mappings/realm` | `n/a` | [Users::addRealmRoles()](src/Resource/Users.php) |
 | `DELETE /{realm}/users/{id}/role-mappings/realm` | `n/a` | [Users::removeRealmRoles()](src/Resource/Users.php) |
 
+### [Roles](https://www.keycloak.org/docs-api/20.0.0/rest-api/index.html#_roles_resource)
+| Endpoint | Response | API |
+|----------|----------|-----|
+| `GET /admin/realms/{realm}/roles` | [RoleCollection](src/Collection/RoleCollection.php) | [Roles::all()](src/Resource/Roles.php) |
+| `GET /admin/realms/{realm}/roles/{roleName}` | [Role](src/Representation/Role.php) | [Roles::get()](src/Resource/Roles.php) |
+| `POST /admin/realms/{realm}/roles` | `n/a` | [Roles::create()](src/Resource/Roles.php) |
+| `DELETE /admin/realms/{realm}/roles/{roleName}` | `n/a` | [Roles::delete()](src/Resource/Roles.php) |
+
 ### [Root](https://www.keycloak.org/docs-api/20.0.0/rest-api/index.html#_root_resource)
 | Endpoint | Response | API |
 |----------|----------|-----|

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,8 @@
         "phpstan": "docker compose run --rm --no-deps php vendor/bin/phpstan analyze src tests examples",
         "psalm": "docker compose run --rm --no-deps php vendor/bin/psalm src tests examples",
         "test": [
-            "@test-unit",
-            "@test-integration"
+            "@test:unit",
+            "@test:integration"
         ],
         "test:unit": "docker compose run --rm --no-deps php vendor/bin/phpunit --testsuite unit",
         "test:integration": "docker compose run --rm --no-deps php vendor/bin/phpunit --testsuite integration"

--- a/src/Collection/RoleCollection.php
+++ b/src/Collection/RoleCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fschmtt\Keycloak\Collection;
+
+use Fschmtt\Keycloak\Representation\Role;
+
+/**
+ * @method Role[] getIterator()
+ * @codeCoverageIgnore
+ */
+class RoleCollection extends Collection
+{
+    public static function getRepresentationClass(): string
+    {
+        return Role::class;
+    }
+}

--- a/src/Http/Command.php
+++ b/src/Http/Command.php
@@ -8,12 +8,22 @@ use Fschmtt\Keycloak\Representation\Representation;
 
 class Command
 {
+    /**
+     * @param Representation[]|Representation|null $payload
+     */
     public function __construct(
         private readonly string $path,
         private readonly Method $method,
         private readonly array $parameters = [],
-        private readonly ?Representation $representation = null,
+        private readonly array|Representation|null $payload = null,
     ) {
+        if (is_array($payload)) {
+            foreach ($payload as $representation) {
+                if (!$representation instanceof Representation) {
+                    throw new \TypeError(sprintf('"%s()" expects parameter 4 to be an array of Representation objects, but it contains "%s".', __METHOD__, get_debug_type($representation)));
+                }
+            }
+        }
     }
 
     public function getMethod(): Method
@@ -37,8 +47,8 @@ class Command
         );
     }
 
-    public function getRepresentation(): ?Representation
+    public function getPayload(): array|Representation|null
     {
-        return $this->representation;
+        return $this->payload;
     }
 }

--- a/src/Http/CommandExecutor.php
+++ b/src/Http/CommandExecutor.php
@@ -20,13 +20,26 @@ class CommandExecutor
             $command->getMethod()->value,
             $command->getPath(),
             [
-                'body' => $command->getRepresentation()
-                    ? (new JsonEncoder())->encode($this->propertyFilter->filter($command->getRepresentation()))
-                    : null,
+                'body' => $this->prepareBody($command),
                 'headers' => [
                     'Content-Type' => 'application/json',
                 ],
             ]
         );
+    }
+
+    protected function prepareBody(Command $command): ?string
+    {
+        if ($command->getPayload() === null) {
+            return null;
+        }
+
+        if (is_array($command->getPayload())) {
+            $payload = array_map([$this->propertyFilter, 'filter'], $command->getPayload());
+        } else {
+            $payload = $this->propertyFilter->filter($command->getPayload());
+        }
+
+        return (new JsonEncoder())->encode($payload);
     }
 }

--- a/src/Keycloak.php
+++ b/src/Keycloak.php
@@ -12,6 +12,7 @@ use Fschmtt\Keycloak\Resource\AttackDetection;
 use Fschmtt\Keycloak\Resource\Clients;
 use Fschmtt\Keycloak\Resource\Groups;
 use Fschmtt\Keycloak\Resource\Realms;
+use Fschmtt\Keycloak\Resource\Roles;
 use Fschmtt\Keycloak\Resource\ServerInfo;
 use Fschmtt\Keycloak\Resource\Users;
 use Fschmtt\Keycloak\Serializer\Factory as SerializerFactory;
@@ -89,6 +90,13 @@ class Keycloak
         $this->fetchVersion();
 
         return new Groups($this->commandExecutor, $this->queryExecutor);
+    }
+
+    public function roles(): Roles
+    {
+        $this->fetchVersion();
+
+        return new Roles($this->commandExecutor, $this->queryExecutor);
     }
 
     private function fetchVersion(): void

--- a/src/Resource/Roles.php
+++ b/src/Resource/Roles.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fschmtt\Keycloak\Resource;
+
+use Fschmtt\Keycloak\Collection\RoleCollection;
+use Fschmtt\Keycloak\Http\Command;
+use Fschmtt\Keycloak\Http\Criteria;
+use Fschmtt\Keycloak\Http\Method;
+use Fschmtt\Keycloak\Http\Query;
+use Fschmtt\Keycloak\Representation\Role;
+
+class Roles extends Resource
+{
+    public function all(string $realm, ?Criteria $criteria = null): RoleCollection
+    {
+        return $this->queryExecutor->executeQuery(
+            new Query(
+                '/admin/realms/{realm}/roles',
+                RoleCollection::class,
+                [
+                    'realm' => $realm,
+                ],
+                $criteria
+            )
+        );
+    }
+
+    public function get(string $realm, string $roleName): Role
+    {
+        return $this->queryExecutor->executeQuery(
+            new Query(
+                '/admin/realms/{realm}/roles/{roleName}',
+                Role::class,
+                [
+                    'realm' => $realm,
+                    'roleName' => $roleName,
+                ]
+            )
+        );
+    }
+
+    public function create(string $realm, Role $role): void
+    {
+        $this->commandExecutor->executeCommand(
+            new Command(
+                '/admin/realms/{realm}/roles',
+                Method::POST,
+                [
+                    'realm' => $realm,
+                ],
+                $role,
+            )
+        );
+    }
+
+    public function delete(string $realm, string $roleName): void
+    {
+        $this->commandExecutor->executeCommand(
+            new Command(
+                '/admin/realms/{realm}/roles/{roleName}',
+                Method::DELETE,
+                [
+                    'realm' => $realm,
+                    'roleName' => $roleName,
+                ],
+            )
+        );
+    }
+}

--- a/src/Resource/Users.php
+++ b/src/Resource/Users.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fschmtt\Keycloak\Resource;
 
 use Fschmtt\Keycloak\Collection\GroupCollection;
+use Fschmtt\Keycloak\Collection\RoleCollection;
 use Fschmtt\Keycloak\Collection\UserCollection;
 use Fschmtt\Keycloak\Http\Command;
 use Fschmtt\Keycloak\Http\Criteria;
@@ -140,6 +141,64 @@ class Users extends Resource
                     'userId' => $userId,
                 ],
                 $criteria
+            )
+        );
+    }
+
+    public function retrieveRealmRoles(string $realm, string $userId): RoleCollection
+    {
+        return $this->queryExecutor->executeQuery(
+            new Query(
+                '/admin/realms/{realm}/users/{userId}/role-mappings/realm',
+                RoleCollection::class,
+                [
+                    'realm' => $realm,
+                    'userId' => $userId,
+                ]
+            )
+        );
+    }
+
+    public function retrieveAvailableRealmRoles(string $realm, string $userId): RoleCollection
+    {
+        return $this->queryExecutor->executeQuery(
+            new Query(
+                '/admin/realms/{realm}/users/{userId}/role-mappings/realm/available',
+                RoleCollection::class,
+                [
+                    'realm' => $realm,
+                    'userId' => $userId,
+                ]
+            )
+        );
+    }
+
+    public function addRealmRoles(string $realm, string $userId, array $roles): void
+    {
+        $this->commandExecutor->executeCommand(
+            new Command(
+                '/admin/realms/{realm}/users/{userId}/role-mappings/realm',
+                Method::POST,
+                [
+                    'realm' => $realm,
+                    'userId' => $userId,
+                ],
+                $roles
+            )
+        );
+    }
+
+    public function removeRealmRoles(string $realm, string $userId, array $roles): void
+    {
+        $this->commandExecutor->executeCommand(
+            new Command(
+                '/admin/realms/{realm}/users/{userId}/role-mappings/realm',
+                Method::DELETE,
+                [
+                    'realm' => $realm,
+                    'userId' => $userId,
+                ],
+                $roles
             )
         );
     }

--- a/tests/Integration/Resource/RolesTest.php
+++ b/tests/Integration/Resource/RolesTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fschmtt\Keycloak\Test\Integration\Resource;
+
+use Exception;
+use Fschmtt\Keycloak\Http\Criteria;
+use Fschmtt\Keycloak\Representation\Role;
+use Fschmtt\Keycloak\Test\Integration\IntegrationTestBehaviour;
+use PHPUnit\Framework\TestCase;
+
+class RolesTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testCreateRetrieveDeleteRole(): void
+    {
+        $resource = $this->getKeycloak()->roles();
+
+        // Get all roles
+        $allRoles = $resource->all('master');
+        static::assertGreaterThanOrEqual(1, $allRoles->count());
+        $role = $allRoles->first();
+        static::assertInstanceOf(Role::class, $role);
+
+        // Create role
+        $resource->create(
+            'master',
+            new Role(name: 'test-role', description: 'test-role-description')
+        );
+
+        // Search (created) role
+        $role = $resource->all('master', new Criteria([
+            'search' => 'test-role',
+        ]))->first();
+        static::assertInstanceOf(Role::class, $role);
+        static::assertEquals('test-role', $role->getName());
+
+        // Get single (created) role
+        $role = $resource->get('master', 'test-role');
+        static::assertSame('test-role', $role->getName());
+
+        // Delete (created) role
+        $resource->delete('master', 'test-role');
+
+        try {
+            $resource->get('master', 'test-role');
+            static::fail('Role should not exist anymore');
+        } catch (Exception $e) {
+            static::assertSame(404, $e->getCode());
+        }
+    }
+}

--- a/tests/Integration/Resource/UsersTest.php
+++ b/tests/Integration/Resource/UsersTest.php
@@ -7,6 +7,7 @@ namespace Fschmtt\Keycloak\Test\Integration\Resource;
 use Exception;
 use Fschmtt\Keycloak\Http\Criteria;
 use Fschmtt\Keycloak\Representation\Group;
+use Fschmtt\Keycloak\Representation\Role;
 use Fschmtt\Keycloak\Representation\User;
 use Fschmtt\Keycloak\Test\Integration\IntegrationTestBehaviour;
 use PHPUnit\Framework\TestCase;
@@ -99,5 +100,42 @@ class UsersTest extends TestCase
 
         // remove the temp group
         $groups->delete('master', $group->getId());
+    }
+
+    public function testAddRemoveRealmRoleUser(): void
+    {
+        $users = $this->getKeycloak()->users();
+        $user = $users->all('master')->first();
+
+        // retrieve user's roles and count them
+        $roles = $users->retrieveRealmRoles('master', $user->getId());
+        $cntRoles = $roles->count();
+
+        // retrieve user's available roles and count them
+        $availableRoles = $users->retrieveAvailableRealmRoles('master', $user->getId());
+        $cntAvailableRoles = $availableRoles->count();
+        static::assertGreaterThanOrEqual(1, $cntAvailableRoles);
+        $role = $availableRoles->first();
+        static::assertInstanceOf(Role::class, $role);
+
+        // add the first available role to the user
+        $users->addRealmRoles('master', $user->getId(), [$role]);
+
+        $roles = $users->retrieveRealmRoles('master', $user->getId());
+        static::assertEquals($cntRoles + 1, $roles->count());
+        static::assertContainsEquals($role, $roles);
+
+        $availableRoles = $users->retrieveAvailableRealmRoles('master', $user->getId());
+        static::assertEquals($cntAvailableRoles - 1, $availableRoles->count());
+
+        // remove the role from the user (back to the initial state)
+        $users->removeRealmRoles('master', $user->getId(), [$role]);
+
+        $roles = $users->retrieveRealmRoles('master', $user->getId());
+        static::assertEquals($cntRoles, $roles->count());
+        static::assertNotContainsEquals($role, $roles);
+
+        $availableRoles = $users->retrieveAvailableRealmRoles('master', $user->getId());
+        static::assertEquals($cntAvailableRoles, $availableRoles->count());
     }
 }

--- a/tests/Unit/Http/CommandExecutorTest.php
+++ b/tests/Unit/Http/CommandExecutorTest.php
@@ -51,7 +51,7 @@ class CommandExecutorTest extends TestCase
             [],
             new Representation()
         );
-        $representation = $command->getRepresentation();
+        $payload = $command->getPayload();
 
         $client = $this->createMock(Client::class);
         $client->expects(static::once())
@@ -60,7 +60,36 @@ class CommandExecutorTest extends TestCase
                 Method::PUT->value,
                 '/path/to/resource',
                 [
-                    'body' => (new JsonEncoder())->encode($representation->jsonSerialize()),
+                    'body' => (new JsonEncoder())->encode($payload->jsonSerialize()),
+                    'headers' => [
+                        'Content-Type' => 'application/json',
+                    ],
+                ]
+            );
+
+        $executor = new CommandExecutor($client, new PropertyFilter());
+        $executor->executeCommand($command);
+    }
+
+    public function testCallsClientWithBodyIfCommandHasArrayOfRepresentations(): void
+    {
+        $representation = new Representation();
+
+        $command = new Command(
+            '/path/to/resource',
+            Method::PUT,
+            [],
+            [$representation]
+        );
+
+        $client = $this->createMock(Client::class);
+        $client->expects(static::once())
+            ->method('request')
+            ->with(
+                Method::PUT->value,
+                '/path/to/resource',
+                [
+                    'body' => (new JsonEncoder())->encode([$representation->jsonSerialize()]),
                     'headers' => [
                         'Content-Type' => 'application/json',
                     ],

--- a/tests/Unit/Http/CommandTest.php
+++ b/tests/Unit/Http/CommandTest.php
@@ -14,19 +14,36 @@ use PHPUnit\Framework\TestCase;
  */
 class CommandTest extends TestCase
 {
-    public function testHasNoRepresentationByDefault(): void
+    public function testHasNoPayloadByDefault(): void
     {
-        static::assertNull((new Command('/path', Method::POST))->getRepresentation());
+        static::assertNull((new Command('/path', Method::POST))->getPayload());
     }
 
-    public function testCanGetRepresentation(): void
+    public function testCanGetPayload(): void
     {
         $representation = new Representation();
 
         static::assertSame(
             $representation,
-            (new Command('/path', Method::POST, [], $representation))->getRepresentation()
+            (new Command('/path', Method::POST, [], $representation))->getPayload()
         );
+    }
+
+    public function testCanGetPayloadWithArray(): void
+    {
+        $payload = [new Representation()];
+
+        static::assertSame(
+            $payload,
+            (new Command('/path', Method::POST, [], $payload))->getPayload()
+        );
+    }
+
+    public function testInvalidPayloadThrowsException(): void
+    {
+        $this->expectException(\TypeError::class);
+        /** @psalm-suppress InvalidArgument */
+        new Command('/path', Method::POST, [], [1, 2, 3]);
     }
 
     public function testSubstitutesParametersInPath(): void

--- a/tests/Unit/Resource/RolesTest.php
+++ b/tests/Unit/Resource/RolesTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fschmtt\Keycloak\Test\Unit\Resource;
+
+use Fschmtt\Keycloak\Collection\RoleCollection;
+use Fschmtt\Keycloak\Http\Command;
+use Fschmtt\Keycloak\Http\CommandExecutor;
+use Fschmtt\Keycloak\Http\Method;
+use Fschmtt\Keycloak\Http\Query;
+use Fschmtt\Keycloak\Http\QueryExecutor;
+use Fschmtt\Keycloak\Representation\Role;
+use Fschmtt\Keycloak\Resource\Roles;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Fschmtt\Keycloak\Resource\Roles
+ */
+class RolesTest extends TestCase
+{
+    public function testGetAllRoles(): void
+    {
+        $query = new Query(
+            '/admin/realms/{realm}/roles',
+            RoleCollection::class,
+            [
+                'realm' => 'test-realm',
+            ],
+        );
+
+        $clientCollection = new RoleCollection([
+            new Role(id: 'test-role-1'),
+            new Role(id: 'test-role-2'),
+        ]);
+
+        $queryExecutor = $this->createMock(QueryExecutor::class);
+        $queryExecutor->expects(static::once())
+            ->method('executeQuery')
+            ->with($query)
+            ->willReturn($clientCollection);
+
+        $clients = new Roles(
+            $this->createMock(CommandExecutor::class),
+            $queryExecutor,
+        );
+
+        static::assertSame(
+            $clientCollection,
+            $clients->all('test-realm')
+        );
+    }
+
+    public function testGetRole(): void
+    {
+        $query = new Query(
+            '/admin/realms/{realm}/roles/{roleName}',
+            Role::class,
+            [
+                'realm' => 'test-realm',
+                'roleName' => 'test-role',
+            ],
+        );
+
+        $client = new Role(id: 'test-role-1');
+
+        $queryExecutor = $this->createMock(QueryExecutor::class);
+        $queryExecutor->expects(static::once())
+            ->method('executeQuery')
+            ->with($query)
+            ->willReturn($client);
+
+        $clients = new Roles(
+            $this->createMock(CommandExecutor::class),
+            $queryExecutor,
+        );
+
+        static::assertSame(
+            $client,
+            $clients->get('test-realm', 'test-role')
+        );
+    }
+
+    public function testCreateRole(): void
+    {
+        $createdRole = new Role(id: 'uuid', name: 'created-role');
+
+        $command = new Command(
+            '/admin/realms/{realm}/roles',
+            Method::POST,
+            [
+                'realm' => 'test-realm',
+            ],
+            $createdRole,
+        );
+
+        $commandExecutor = $this->createMock(CommandExecutor::class);
+        $commandExecutor->expects(static::once())
+            ->method('executeCommand')
+            ->with($command);
+
+        $roles = new Roles(
+            $commandExecutor,
+            $this->createMock(QueryExecutor::class),
+        );
+
+        $roles->create('test-realm', $createdRole);
+    }
+
+    public function testDeleteRole(): void
+    {
+        $deletedRole = new Role(name: 'deleted-role');
+
+        $command = new Command(
+            '/admin/realms/{realm}/roles/{roleName}',
+            Method::DELETE,
+            [
+                'realm' => 'test-realm',
+                'roleName' => $deletedRole->getName(),
+            ],
+        );
+
+        $commandExecutor = $this->createMock(CommandExecutor::class);
+        $commandExecutor->expects(static::once())
+            ->method('executeCommand')
+            ->with($command);
+
+        $roles = new Roles(
+            $commandExecutor,
+            $this->createMock(QueryExecutor::class),
+        );
+
+        $roles->delete('test-realm', $deletedRole->getName());
+    }
+}


### PR DESCRIPTION
Hi (me again),

I needed realm-level role management that was not implemented yet so I took care of it ([this endpoint](https://www.keycloak.org/docs-api/15.0/rest-api/index.html#_addrealmrolemappings) and following).

Please note that I had to make a change in the `Command.php` file to accept an array payload, I hope my implementation suits you.

I added the unit and integration tests and, like last time, feedback are very welcome.