### PR TITLE
Credential Representation: CredentialData must be string instead of int

### DIFF
--- a/src/Representation/Credential.php
+++ b/src/Representation/Credential.php
@@ -30,7 +30,7 @@ class Credential extends Representation
 {
     public function __construct(
         protected ?int $createdDate = null,
-        protected ?int $credentialData = null,
+        protected ?string $credentialData = null,
         protected ?string $id = null,
         protected ?int $priority = null,
         protected ?string $secretData = null,

--- a/src/Representation/Credential.php
+++ b/src/Representation/Credential.php
@@ -6,7 +6,7 @@ namespace Fschmtt\Keycloak\Representation;
 
 /**
  * @method int|null getCreatedDate()
- * @method int|null getCredentialData()
+ * @method string|null getCredentialData()
  * @method string|null getId()
  * @method int|null getPriority()
  * @method string|null getSecretData()
@@ -15,7 +15,7 @@ namespace Fschmtt\Keycloak\Representation;
  * @method string|null getUserLabel()
  * @method string|null getValue()
  * @method self withCreatedDate(?int $createdDate)
- * @method self withCredentialData(?int $credentialData)
+ * @method self withCredentialData(?string $credentialData)
  * @method self withId(?string $id)
  * @method self withPriority(?int $priority)
  * @method self withSecretData(?string $secretData)


### PR DESCRIPTION
According to https://www.keycloak.org/docs-api/20.0.3/rest-api/index.html#_credentialrepresentation, CredentialData is a string, not an integer.