### PR TITLE
Fix type totp from string to bool

### DIFF
--- a/src/Representation/User.php
+++ b/src/Representation/User.php
@@ -32,7 +32,7 @@ use Fschmtt\Keycloak\Type\Map;
  * @method array|null getRequiredActions()
  * @method string|null getSelf()
  * @method string|null getServiceAccountClientId()
- * @method string|null getTotp()
+ * @method bool|null getTotp()
  * @method string|null getUsername()
  * @method self withAccess(?Map $access)
  * @method self withAttributes(?Map $attributes)
@@ -56,7 +56,7 @@ use Fschmtt\Keycloak\Type\Map;
  * @method self withRequiredActions(?array $requiredActions)
  * @method self withSelf(?string $self)
  * @method self withServiceAccountClientId(?string $serviceAccountClientId)
- * @method self withTotp(?string $totp)
+ * @method self withTotp(?bool $totp)
  * @method self withUsername(?string $username)
  *
  * @codeCoverageIgnore
@@ -90,7 +90,7 @@ class User extends Representation
         protected ?array $requiredActions = null,
         protected ?string $self = null,
         protected ?string $serviceAccountClientId = null,
-        protected ?string $totp = null,
+        protected ?bool $totp = null,
         protected ?string $username = null,
     ) {
     }


### PR DESCRIPTION
With the current payload keycloak return this log 

```
keycloak-keycloak-1  | 2023-05-23 09:54:30,173 ERROR [org.keycloak.services.error.KeycloakErrorHandler] (executor-thread-46) Uncaught server error: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `java.lang.Boolean` from String "1": only "true" or "false" recognized
keycloak-keycloak-1  |  at [Source: (io.quarkus.vertx.http.runtime.VertxInputStream); line: 1, column: 590] (through reference chain: org.keycloak.representations.idm.UserRepresentation["totp"])
```

