### PR TITLE
adjustments regarding the new subgroup behavior since keycloak 23.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,15 @@ More examples can be found in the [examples](examples) directory.
 | `POST /admin/realms/{realm}/clients` | [Client](src/Representation/Client.php) | [Clients::import()](src/Resource/Clients.php) |
 
 ### [Groups](https://www.keycloak.org/docs-api/23.0.0/rest-api/index.html#_clients_resource)
-| Endpoint | Response | API |
-|----------|----------|-----|
-| `GET /admin/realms/{realm}/groups` | [GroupCollection](src/Collection/GroupCollection.php) | [Groups::all()](src/Resource/Groups.php) |
-| `GET /admin/realms/{realm}/groups/{id}` | [Group](src/Representation/Group.php) | [Groups::get()](src/Resource/Groups.php) |
-| `PUT /admin/realms/{realm}/groups/{id}` | `n/a` | [Groups::update()](src/Resource/Groups.php) |
-| `POST /admin/realms/{realm}/groups` | `n/a` | [Groups::import()](src/Resource/Groups.php) |
-| `DELETE /admin/realms/{realm}/groups` | `n/a` | [Groups::delete()](src/Resource/Groups.php) |
+| Endpoint                                          | Response | API                                           |
+|---------------------------------------------------|----------|-----------------------------------------------|
+| `GET /admin/realms/{realm}/groups`                | [GroupCollection](src/Collection/GroupCollection.php) | [Groups::all()](src/Resource/Groups.php)      |
+| `GET /admin/realms/{realm}/groups/{id}/children`  | [GroupCollection](src/Collection/GroupCollection.php) | [Groups::children()](src/Resource/Groups.php) |
+| `GET /admin/realms/{realm}/groups/{id}`           | [Group](src/Representation/Group.php) | [Groups::get()](src/Resource/Groups.php)      |
+| `PUT /admin/realms/{realm}/groups/{id}`           | `n/a` | [Groups::update()](src/Resource/Groups.php)   |
+| `POST /admin/realms/{realm}/groups`               | `n/a` | [Groups::create()](src/Resource/Groups.php)   |
+| `POST /admin/realms/{realm}/groups/{id}/children` | `n/a` | [Groups::create()](src/Resource/Groups.php)   |
+| `DELETE /admin/realms/{realm}/groups`             | `n/a` | [Groups::delete()](src/Resource/Groups.php)   |
 
 ### [Realms Admin](https://www.keycloak.org/docs-api/23.0.0/rest-api/index.html#_realms_admin_resource)
 | Endpoint | Response | API |

--- a/src/Representation/Group.php
+++ b/src/Representation/Group.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Fschmtt\Keycloak\Representation;
 
 use Fschmtt\Keycloak\Attribute\Since;
-use Fschmtt\Keycloak\Attribute\Until;
 use Fschmtt\Keycloak\Collection\GroupCollection;
 use Fschmtt\Keycloak\Type\Map;
 
@@ -15,6 +14,7 @@ use Fschmtt\Keycloak\Type\Map;
  * @method Map|null getClientRoles()
  * @method string|null getId()
  * @method string|null getName()
+ * @method string|null getParentId()
  * @method string|null getPath()
  * @method string[]|null getRealmRoles()
  * @method int|null getSubGroupCount()
@@ -24,6 +24,7 @@ use Fschmtt\Keycloak\Type\Map;
  * @method self withClientRoles(?Map $clientRoles)
  * @method self withId(?string $id)
  * @method self withName(?string $name)
+ * @method self withParentId(?string $parentId)
  * @method self withPath(?string $path)
  * @method self withRealmRoles(?array $realmRoles)
  * @method self withSubGroupCount(?int $subGroupCount)
@@ -39,14 +40,13 @@ class Group extends Representation
         protected ?Map $clientRoles = null,
         protected ?string $id = null,
         protected ?string $name = null,
+        #[Since('23.0.0')]
+        protected ?string $parentId = null,
         protected ?string $path = null,
         /** @var string[]|null */
         protected ?array $realmRoles = null,
         #[Since('23.0.0')]
         protected ?int $subGroupCount = null,
-        #[Since('23.0.0')]
-        protected ?string $parentId = null,
-        #[Until('23.0.0')]
         protected ?GroupCollection $subGroups = null,
     ) {
     }

--- a/src/Representation/Group.php
+++ b/src/Representation/Group.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fschmtt\Keycloak\Representation;
 
 use Fschmtt\Keycloak\Attribute\Since;
+use Fschmtt\Keycloak\Attribute\Until;
 use Fschmtt\Keycloak\Collection\GroupCollection;
 use Fschmtt\Keycloak\Type\Map;
 
@@ -43,6 +44,9 @@ class Group extends Representation
         protected ?array $realmRoles = null,
         #[Since('23.0.0')]
         protected ?int $subGroupCount = null,
+        #[Since('23.0.0')]
+        protected ?string $parentId = null,
+        #[Until('23.0.0')]
         protected ?GroupCollection $subGroups = null,
     ) {
     }

--- a/src/Resource/Groups.php
+++ b/src/Resource/Groups.php
@@ -35,7 +35,7 @@ class Groups extends Resource
                 GroupCollection::class,
                 [
                     'realm' => $realm,
-                    'groupId' => $groupId
+                    'groupId' => $groupId,
                 ],
                 $criteria
             )
@@ -58,31 +58,31 @@ class Groups extends Resource
 
     public function create(string $realm, Group $group, ?string $parentGroupId = null): void
     {
-        if ($parentGroupId == null) {
-            $this->commandExecutor->executeCommand(
-                new Command(
-                    '/admin/realms/{realm}/groups',
-                    Method::POST,
-                    [
-                        'realm' => $realm,
-                    ],
-                    $group
-                )
-            );
-        } else {
-            $this->commandExecutor->executeCommand(
-                new Command(
-                    '/admin/realms/{realm}/groups/{groupId}/children',
-                    Method::POST,
-                    [
-                        'realm' => $realm,
-                        'groupId' => $parentGroupId
-                    ],
-                    $group
-                )
-            );
-        }
+        $this->commandExecutor->executeCommand(
+            new Command(
+                '/admin/realms/{realm}/groups',
+                Method::POST,
+                [
+                    'realm' => $realm,
+                ],
+                $group
+            )
+        );
+    }
 
+    public function createChild(string $realm, Group $group, string $parentGroupId): void
+    {
+        $this->commandExecutor->executeCommand(
+            new Command(
+                '/admin/realms/{realm}/groups/{groupId}/children',
+                Method::POST,
+                [
+                    'realm' => $realm,
+                    'groupId' => $parentGroupId,
+                ],
+                $group
+            )
+        );
     }
 
     public function update(string $realm, string $groupId, Group $updatedGroup): void

--- a/src/Resource/Groups.php
+++ b/src/Resource/Groups.php
@@ -56,7 +56,7 @@ class Groups extends Resource
         );
     }
 
-    public function create(string $realm, Group $group, ?string $parentGroupId = null): void
+    public function create(string $realm, Group $group): void
     {
         $this->commandExecutor->executeCommand(
             new Command(

--- a/src/Resource/Groups.php
+++ b/src/Resource/Groups.php
@@ -27,6 +27,21 @@ class Groups extends Resource
         );
     }
 
+    public function children(string $realm, string $groupId, ?Criteria $criteria = null): GroupCollection
+    {
+        return $this->queryExecutor->executeQuery(
+            new Query(
+                '/admin/realms/{realm}/groups/{groupId}/children',
+                GroupCollection::class,
+                [
+                    'realm' => $realm,
+                    'groupId' => $groupId
+                ],
+                $criteria
+            )
+        );
+    }
+
     public function get(string $realm, string $groupId): Group
     {
         return $this->queryExecutor->executeQuery(
@@ -41,18 +56,33 @@ class Groups extends Resource
         );
     }
 
-    public function create(string $realm, Group $group): void
+    public function create(string $realm, Group $group, ?string $parentGroupId = null): void
     {
-        $this->commandExecutor->executeCommand(
-            new Command(
-                '/admin/realms/{realm}/groups',
-                Method::POST,
-                [
-                    'realm' => $realm,
-                ],
-                $group
-            )
-        );
+        if ($parentGroupId == null) {
+            $this->commandExecutor->executeCommand(
+                new Command(
+                    '/admin/realms/{realm}/groups',
+                    Method::POST,
+                    [
+                        'realm' => $realm,
+                    ],
+                    $group
+                )
+            );
+        } else {
+            $this->commandExecutor->executeCommand(
+                new Command(
+                    '/admin/realms/{realm}/groups/{groupId}/children',
+                    Method::POST,
+                    [
+                        'realm' => $realm,
+                        'groupId' => $parentGroupId
+                    ],
+                    $group
+                )
+            );
+        }
+
     }
 
     public function update(string $realm, string $groupId, Group $updatedGroup): void

--- a/tests/Integration/Resource/GroupsTest.php
+++ b/tests/Integration/Resource/GroupsTest.php
@@ -37,7 +37,7 @@ class GroupsTest extends TestCase
         static::assertInstanceOf(Group::class, $group);
 
         //Creat child group
-        $groups->create('master', new Group(name: $childGroupName), $group->getId());
+        $groups->createChild('master', new Group(name: $childGroupName), $group->getId());
 
         // Search for single (imported) group
         $importedGroup = $groups->all('master', new Criteria([
@@ -50,7 +50,7 @@ class GroupsTest extends TestCase
         $childGroup = $groups->children('master', $importedGroup->getId())->first();
         static::assertInstanceOf(Group::class, $childGroup);
         static::assertSame($childGroup->getName(), $childGroupName);
-
+        
         // Update (imported) group
         $groups->update('master', $importedGroup->getId(), $importedGroup->withName($updatedGroupName));
 

--- a/tests/Integration/Resource/GroupsTest.php
+++ b/tests/Integration/Resource/GroupsTest.php
@@ -20,6 +20,7 @@ class GroupsTest extends TestCase
         $groups = $this->getKeycloak()->groups();
 
         $importedGroupName = Uuid::uuid4()->toString();
+        $childGroupName = Uuid::uuid4()->toString();
         $updatedGroupName = Uuid::uuid4()->toString();
 
         // Create group
@@ -28,11 +29,15 @@ class GroupsTest extends TestCase
             new Group(name: $importedGroupName),
         );
 
+
         // Get all groups
         $allGroups = $groups->all('master');
         static::assertGreaterThanOrEqual(1, $allGroups->count());
         $group = $allGroups->first();
         static::assertInstanceOf(Group::class, $group);
+
+        //Creat child group
+        $groups->create('master', new Group(name: $childGroupName), $group->getId());
 
         // Search for single (imported) group
         $importedGroup = $groups->all('master', new Criteria([
@@ -40,6 +45,11 @@ class GroupsTest extends TestCase
         ]))->first();
         static::assertInstanceOf(Group::class, $importedGroup);
         static::assertSame($importedGroupName, $importedGroup->getName());
+
+        //get the child group
+        $childGroup = $groups->children('master', $importedGroup->getId())->first();
+        static::assertInstanceOf(Group::class, $childGroup);
+        static::assertSame($childGroup->getName(), $childGroupName);
 
         // Update (imported) group
         $groups->update('master', $importedGroup->getId(), $importedGroup->withName($updatedGroupName));

--- a/tests/Integration/Resource/GroupsTest.php
+++ b/tests/Integration/Resource/GroupsTest.php
@@ -65,7 +65,7 @@ class GroupsTest extends TestCase
         $groups = $this->getKeycloak()->groups();
 
         // Create group
-        $groups->create('master', new Group(name: $importedGroupName),);
+        $groups->create('master', new Group(name: $importedGroupName));
         $group = $groups->all('master')->first();
         static::assertInstanceOf(Group::class, $group);
 

--- a/tests/Unit/Resource/GroupsTest.php
+++ b/tests/Unit/Resource/GroupsTest.php
@@ -50,6 +50,40 @@ class GroupsTest extends TestCase
         static::assertSame('group-1', $groups->first()->getId());
     }
 
+    public function testGetGroupChildren(): void
+    {
+        $query = new Query(
+            '/admin/realms/{realm}/groups/{groupId}/children',
+            GroupCollection::class,
+            [
+                'realm' => 'realm-with-groups',
+                'groupId' => 'child-group-id'
+            ],
+        );
+
+        $queryExecutor = $this->createMock(QueryExecutor::class);
+        $queryExecutor->expects(static::once())
+            ->method('executeQuery')
+            ->with($query)
+            ->willReturn(
+                new GroupCollection([
+                    new Group(id: 'group-1'),
+                    new Group(id: 'group-2'),
+                ]),
+            );
+
+        $groups = new Groups(
+            $this->createMock(CommandExecutor::class),
+            $queryExecutor,
+        );
+        $groups = $groups->children('realm-with-groups', 'child-group-id');
+
+        static::assertCount(2, $groups);
+        static::assertInstanceOf(Group::class, $groups->first());
+        static::assertSame('group-1', $groups->first()->getId());
+
+    }
+
     public function testGetGroup(): void
     {
         $query = new Query(

--- a/tests/Unit/Resource/GroupsTest.php
+++ b/tests/Unit/Resource/GroupsTest.php
@@ -57,7 +57,7 @@ class GroupsTest extends TestCase
             GroupCollection::class,
             [
                 'realm' => 'realm-with-groups',
-                'groupId' => 'child-group-id'
+                'groupId' => 'child-group-id',
             ],
         );
 
@@ -81,7 +81,6 @@ class GroupsTest extends TestCase
         static::assertCount(2, $groups);
         static::assertInstanceOf(Group::class, $groups->first());
         static::assertSame('group-1', $groups->first()->getId());
-
     }
 
     public function testGetGroup(): void
@@ -134,6 +133,33 @@ class GroupsTest extends TestCase
         );
 
         $groups->create('realm-with-groups', $group);
+    }
+
+    public function testCreateChildGroup(): void
+    {
+        $group = new Group(name: 'child-group');
+
+        $command = new Command(
+            '/admin/realms/{realm}/groups/{groupId}/children',
+            Method::POST,
+            [
+                'realm' => 'realm-with-groups',
+                'groupId' => 'parent-group-id',
+            ],
+            $group
+        );
+
+        $commandExecutor = $this->createMock(CommandExecutor::class);
+        $commandExecutor->expects(static::once())
+            ->method('executeCommand')
+            ->with($command);
+
+        $groups = new Groups(
+            $commandExecutor,
+            $this->createMock(QueryExecutor::class),
+        );
+
+        $groups->createChild('realm-with-groups', $group, 'parent-group-id');
     }
 
     public function testUpdateGroup(): void


### PR DESCRIPTION
Hi,
frist of all nice libaray. Thank you for all the great work.
Since Keycloak 23.0.0 there is a new endpoint which is used to provide the subgroups of a group. 
GET /admin/realms/{realm}/groups/{id}/children
Retrieving information from the subgroup property is no longer possible. The array is empty. 