### PR TITLE
Removed id on resource.php

### DIFF
--- a/src/Representation/Resource.php
+++ b/src/Representation/Resource.php
@@ -13,7 +13,6 @@ use Fschmtt\Keycloak\Type\Map;
 class Resource extends Representation
 {
     public function __construct(
-        protected ?string $id,
         protected ?Map $attributes,
         protected ?string $displayName,
         protected ?string $icon_uri,


### PR DESCRIPTION
Solves this issue: Occurs in Keycloak 23.

Client error: `POST http://.../admin/realms/.../clients` resulted in a `400 Bad Request` response:\n
    {"error":"Unrecognized field \"id\" (class org.keycloak.representations.idm.authorization.ResourceRepresentation), not m (truncated...).