### PR TITLE
fix(serialization): incorrect map serialization

### DIFF
--- a/src/Serializer/MapNormalizer.php
+++ b/src/Serializer/MapNormalizer.php
@@ -15,7 +15,9 @@ class MapNormalizer implements NormalizerInterface
      */
     public function normalize(mixed $object, ?string $format = null, array $context = []): ArrayObject
     {
-        return new ArrayObject($object);
+        assert($object instanceof Map);
+
+        return new ArrayObject($object->map);
     }
 
     /**

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -44,6 +44,7 @@ class Serializer
             new ArrayDenormalizer(),
             new CollectionDenormalizer($propertyNormalizer),
             new MapNormalizer(),
+            new MapDenormalizer(),
             new AttributeNormalizer($propertyNormalizer, $keycloakVersion),
             $propertyNormalizer,
         ], [

--- a/src/Type/Map.php
+++ b/src/Type/Map.php
@@ -22,7 +22,7 @@ class Map extends Type implements Countable, IteratorAggregate
      * @param array<mixed> $map
      */
     public function __construct(
-        private readonly array $map = [],
+        readonly array $map = [],
     ) {}
 
     public function jsonSerialize(): object

--- a/tests/Integration/Resource/RealmsTest.php
+++ b/tests/Integration/Resource/RealmsTest.php
@@ -7,6 +7,7 @@ namespace Fschmtt\Keycloak\Test\Integration\Resource;
 use Fschmtt\Keycloak\Collection\RealmCollection;
 use Fschmtt\Keycloak\Representation\Realm;
 use Fschmtt\Keycloak\Test\Integration\IntegrationTestBehaviour;
+use Fschmtt\Keycloak\Type\Map;
 use PHPUnit\Framework\TestCase;
 
 class RealmsTest extends TestCase
@@ -102,5 +103,22 @@ class RealmsTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         $this->getKeycloak()->realms()->deleteAdminEvents('master');
+    }
+
+    public function testCanUpdateRealmAttributes(): void
+    {
+        $realm = $this->getKeycloak()->realms()->get(realm: 'master');
+
+        static::assertNull($realm->getAttributes()->map['termsUrl']);
+
+        $realm = $realm->withAttributes(new Map([
+            'termsUrl' => 'https://example.com/terms',
+        ]));
+
+        $this->getKeycloak()->realms()->update($realm->getRealm(), $realm);
+
+        $updatedRealm = $this->getKeycloak()->realms()->get(realm: $realm->getRealm());
+
+        static::assertEquals('https://example.com/terms', $updatedRealm->getAttributes()->map['termsUrl']);
     }
 }

--- a/tests/Unit/Serializer/MapNormalizerTest.php
+++ b/tests/Unit/Serializer/MapNormalizerTest.php
@@ -17,40 +17,41 @@ class MapNormalizerTest extends TestCase
 {
     public function testSupportedTypes(): void
     {
-        $denormalizer = new MapNormalizer();
+        $normalizer = new MapNormalizer();
 
         static::assertSame(
             [Map::class => true],
-            $denormalizer->getSupportedTypes('json'),
+            $normalizer->getSupportedTypes('json'),
         );
     }
 
     public function testSupportsNormalization(): void
     {
-        $denormalizer = new MapNormalizer();
+        $normalizer = new MapNormalizer();
 
-        static::assertTrue($denormalizer->supportsNormalization(new Map()));
-        static::assertFalse($denormalizer->supportsNormalization([]));
+        static::assertTrue($normalizer->supportsNormalization(new Map()));
+        static::assertFalse($normalizer->supportsNormalization([]));
     }
+
     #[DataProvider('maps')]
     public function testNormalize(mixed $value, ArrayObject $expected): void
     {
-        $denormalizer = new MapNormalizer();
+        $normalizer = new MapNormalizer();
 
         self::assertEquals(
             $expected,
-            $denormalizer->normalize($value, Map::class),
+            $normalizer->normalize($value, Map::class),
         );
     }
 
     public static function maps(): Generator
     {
         yield 'filled array' => [
-            [
+            new Map([
                 'a' => 1,
                 'b' => 2,
                 'c' => 3,
-            ],
+            ]),
             new ArrayObject([
                 'a' => 1,
                 'b' => 2,
@@ -59,17 +60,8 @@ class MapNormalizerTest extends TestCase
         ];
 
         yield 'empty array' => [
-            [],
+            new Map([]),
             new ArrayObject(),
-        ];
-
-        yield Map::class => [
-            new ArrayObject([
-                'a' => 1,
-            ]),
-            new ArrayObject([
-                'a' => 1,
-            ]),
         ];
     }
 }


### PR DESCRIPTION
When switching to Symfony's serializer, the MapDenormalizer was implemented, but not added to the Serializer parameters. Thus, the attributes of a realm and other fields using the Map type were always empty.

Additionally, the MapNormalizerTest contained test data for the denormalizer. We adjusted this to correctly ingest Map's as the test values.

To properly normalize the Map type, we made the inner array publicly accessible. Previously the ArrayObject would otherwise hold an array with the entire Map object wrapped by the Map classname. This was addressed, by directly accessing the inner array and passing it to the ArrayObject.

We also added an integration test to prevent these kind of issues in the future, and to test the update method for realm attributes.