### PR TITLE
Fix executeActionsEmail via explicit ContentType declaration

### DIFF
--- a/src/Http/Command.php
+++ b/src/Http/Command.php
@@ -20,11 +20,25 @@ class Command
         /** @var Representation|Collection|array<mixed>|null */
         private readonly Representation|Collection|array|null $payload = null,
         private readonly ?Criteria $criteria = null,
+        private readonly ?ContentType $contentType = null,
     ) {}
 
     public function getMethod(): Method
     {
         return $this->method;
+    }
+
+    public function getContentType(): ContentType
+    {
+        if ($this->contentType !== null) {
+            return $this->contentType;
+        }
+
+        if (is_array($this->payload)) {
+            return ContentType::FORM_DATA;
+        }
+
+        return ContentType::JSON;
     }
 
     public function getPath(): string

--- a/src/Http/Command.php
+++ b/src/Http/Command.php
@@ -20,25 +20,12 @@ class Command
         /** @var Representation|Collection|array<mixed>|null */
         private readonly Representation|Collection|array|null $payload = null,
         private readonly ?Criteria $criteria = null,
-        private readonly ?ContentType $contentType = null,
+        private readonly ContentType $contentType = ContentType::JSON,
     ) {}
 
     public function getMethod(): Method
     {
         return $this->method;
-    }
-
-    public function getContentType(): ContentType
-    {
-        if ($this->contentType !== null) {
-            return $this->contentType;
-        }
-
-        if (is_array($this->payload)) {
-            return ContentType::FORM_DATA;
-        }
-
-        return ContentType::JSON;
     }
 
     public function getPath(): string
@@ -74,5 +61,10 @@ class Command
         }
 
         return '?' . http_build_query($this->criteria->jsonSerialize());
+    }
+
+    public function getContentType(): ContentType
+    {
+        return $this->contentType;
     }
 }

--- a/src/Http/CommandExecutor.php
+++ b/src/Http/CommandExecutor.php
@@ -20,29 +20,28 @@ class CommandExecutor
 
     public function executeCommand(Command $command): void
     {
+        $contentType = $command->getContentType();
         $payload = $command->getPayload();
 
-        if (is_array($payload)) {
-            $this->client->request(
-                $command->getMethod()->value,
-                $command->getPath(),
-                [
-                    'form_params' => $payload,
-                ],
-            );
+        $options = [
+            'headers' => [
+                'Content-Type' => $contentType->value,
+            ],
+        ];
 
-            return;
+        switch ($contentType) {
+            case ContentType::JSON:
+                $options['body'] = $this->serializer->serialize($payload);
+                break;
+            case ContentType::FORM_DATA:
+                $options['form_params'] = $payload;
+                break;
         }
 
         $this->client->request(
             $command->getMethod()->value,
             $command->getPath(),
-            [
-                'body' => $this->serializer->serialize($command->getPayload()),
-                'headers' => [
-                    'Content-Type' => 'application/json',
-                ],
-            ],
+            $options,
         );
     }
 }

--- a/src/Http/CommandExecutor.php
+++ b/src/Http/CommandExecutor.php
@@ -25,7 +25,7 @@ class CommandExecutor
                 'body' => $this->serializer->serialize($command->getPayload()),
                 'headers' => [
                     'Content-Type' => $command->getContentType()->value,
-                ]
+                ],
             ],
             ContentType::FORM_PARAMS => ['form_params' => $command->getPayload()],
         };

--- a/src/Http/ContentType.php
+++ b/src/Http/ContentType.php
@@ -10,5 +10,5 @@ namespace Fschmtt\Keycloak\Http;
 enum ContentType: string
 {
     case JSON = 'application/json';
-    case FORM_DATA = 'application/x-www-form-urlencoded';
+    case FORM_PARAMS = 'application/x-www-form-urlencoded';
 }

--- a/src/Http/ContentType.php
+++ b/src/Http/ContentType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fschmtt\Keycloak\Http;
+
+/**
+ * @internal
+ */
+enum ContentType: string
+{
+    case JSON = 'application/json';
+    case FORM_DATA = 'application/x-www-form-urlencoded';
+}

--- a/src/Resource/Organizations.php
+++ b/src/Resource/Organizations.php
@@ -6,6 +6,7 @@ namespace Fschmtt\Keycloak\Resource;
 
 use Fschmtt\Keycloak\Collection\OrganizationCollection;
 use Fschmtt\Keycloak\Http\Command;
+use Fschmtt\Keycloak\Http\ContentType;
 use Fschmtt\Keycloak\Http\Criteria;
 use Fschmtt\Keycloak\Http\Method;
 use Fschmtt\Keycloak\Http\Query;
@@ -71,6 +72,7 @@ class Organizations extends Resource
                     'firstName' => $firstName,
                     'lastName' => $lastName,
                 ],
+                contentType: ContentType::FORM_PARAMS,
             ),
         );
     }

--- a/src/Resource/Users.php
+++ b/src/Resource/Users.php
@@ -9,6 +9,7 @@ use Fschmtt\Keycloak\Collection\GroupCollection;
 use Fschmtt\Keycloak\Collection\RoleCollection;
 use Fschmtt\Keycloak\Collection\UserCollection;
 use Fschmtt\Keycloak\Http\Command;
+use Fschmtt\Keycloak\Http\ContentType;
 use Fschmtt\Keycloak\Http\Criteria;
 use Fschmtt\Keycloak\Http\Method;
 use Fschmtt\Keycloak\Http\Query;
@@ -219,6 +220,7 @@ class Users extends Resource
                 ],
                 $actions,
                 $criteria,
+                ContentType::JSON,
             ),
         );
     }

--- a/src/Resource/Users.php
+++ b/src/Resource/Users.php
@@ -220,7 +220,6 @@ class Users extends Resource
                 ],
                 $actions,
                 $criteria,
-                ContentType::JSON,
             ),
         );
     }

--- a/tests/Integration/Resource/UsersTest.php
+++ b/tests/Integration/Resource/UsersTest.php
@@ -189,6 +189,26 @@ class UsersTest extends TestCase
         static::assertNull($user);
     }
 
+    public function testExecuteActionsEmail(): void
+    {
+        $users = $this->getKeycloak()->users();
+        $username = Uuid::uuid4()->toString();
+
+        $users->create('master', new User(
+            username: $username,
+        ));
+
+        $user = $this->searchUserByUsername($username);
+        static::assertInstanceOf(User::class, $user);
+
+        $users->executeActionsEmail('master', $user->getId(), ['UPDATE_PASSWORD']);
+
+        $users->delete('master', $user->getId());
+
+        $user = $this->searchUserByUsername($username);
+        static::assertNull($user);
+    }
+
     private function searchUserByUsername(string $username, string $realm = 'master'): ?User
     {
         /** @var User|null $user */

--- a/tests/Unit/Http/CommandExecutorTest.php
+++ b/tests/Unit/Http/CommandExecutorTest.php
@@ -118,6 +118,9 @@ class CommandExecutorTest extends TestCase
                 '/path/to/resource',
                 [
                     'form_params' => $payload,
+                    'headers' => [
+                        'Content-Type' => 'application/x-www-form-urlencoded',
+                    ],
                 ],
             );
 

--- a/tests/Unit/Http/CommandExecutorTest.php
+++ b/tests/Unit/Http/CommandExecutorTest.php
@@ -31,7 +31,7 @@ class CommandExecutorTest extends TestCase
                     'body' => null,
                     'headers' => [
                         'Content-Type' => 'application/json',
-                    ]
+                    ],
                 ],
             );
 

--- a/tests/Unit/Http/CommandExecutorTest.php
+++ b/tests/Unit/Http/CommandExecutorTest.php
@@ -7,6 +7,7 @@ namespace Fschmtt\Keycloak\Test\Unit\Http;
 use Fschmtt\Keycloak\Http\Client;
 use Fschmtt\Keycloak\Http\Command;
 use Fschmtt\Keycloak\Http\CommandExecutor;
+use Fschmtt\Keycloak\Http\ContentType;
 use Fschmtt\Keycloak\Http\Method;
 use Fschmtt\Keycloak\Json\JsonEncoder;
 use Fschmtt\Keycloak\Serializer\Serializer;
@@ -30,7 +31,7 @@ class CommandExecutorTest extends TestCase
                     'body' => null,
                     'headers' => [
                         'Content-Type' => 'application/json',
-                    ],
+                    ]
                 ],
             );
 
@@ -43,7 +44,7 @@ class CommandExecutorTest extends TestCase
         );
     }
 
-    public function testCallsClientWithBodyIfCommandHasRepresentation(): void
+    public function testCallsClientWithJsonIfCommandHasRepresentation(): void
     {
         $command = new Command(
             '/path/to/resource',
@@ -101,13 +102,14 @@ class CommandExecutorTest extends TestCase
         $executor->executeCommand($command);
     }
 
-    public function testCallsClientWithFormParamsIfCommandHasArrayPayload(): void
+    public function testCallsClientWithFormParamsIfCommandFormParamContentType(): void
     {
         $command = new Command(
             '/path/to/resource',
             Method::PUT,
             [],
             $payload = ['UPDATE_PASSWORD', 'VERIFY_EMAIL'],
+            contentType: ContentType::FORM_PARAMS,
         );
 
         $client = $this->createMock(Client::class);
@@ -118,9 +120,6 @@ class CommandExecutorTest extends TestCase
                 '/path/to/resource',
                 [
                     'form_params' => $payload,
-                    'headers' => [
-                        'Content-Type' => 'application/x-www-form-urlencoded',
-                    ],
                 ],
             );
 

--- a/tests/Unit/Http/CommandTest.php
+++ b/tests/Unit/Http/CommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fschmtt\Keycloak\Test\Unit\Http;
 
 use Fschmtt\Keycloak\Http\Command;
+use Fschmtt\Keycloak\Http\ContentType;
 use Fschmtt\Keycloak\Http\Criteria;
 use Fschmtt\Keycloak\Http\Method;
 use Fschmtt\Keycloak\Test\Unit\Stub\Collection;
@@ -83,5 +84,19 @@ class CommandTest extends TestCase
                 ]),
             ))->getPath(),
         );
+    }
+
+    public function testContentTypeDefaultsToJson(): void
+    {
+        $command = new Command('/path', Method::GET);
+
+        static::assertSame(ContentType::JSON, $command->getContentType());
+    }
+
+    public function testContentTypeCanBeSetToFormParams(): void
+    {
+        $command = new Command('/path', Method::GET, contentType: ContentType::FORM_PARAMS);
+
+        static::assertSame(ContentType::FORM_PARAMS, $command->getContentType());
     }
 }

--- a/tests/Unit/Resource/OrganizationsTest.php
+++ b/tests/Unit/Resource/OrganizationsTest.php
@@ -7,6 +7,7 @@ namespace Fschmtt\Keycloak\Test\Unit\Resource;
 use Fschmtt\Keycloak\Collection\OrganizationCollection;
 use Fschmtt\Keycloak\Http\Command;
 use Fschmtt\Keycloak\Http\CommandExecutor;
+use Fschmtt\Keycloak\Http\ContentType;
 use Fschmtt\Keycloak\Http\Method;
 use Fschmtt\Keycloak\Http\Query;
 use Fschmtt\Keycloak\Http\QueryExecutor;
@@ -148,6 +149,7 @@ class OrganizationsTest extends TestCase
                 'firstName' => 'first name',
                 'lastName' => 'last name',
             ],
+            contentType: ContentType::FORM_PARAMS,
         );
 
         $commandExecutor = $this->createMock(CommandExecutor::class);

--- a/tests/Unit/Resource/UsersTest.php
+++ b/tests/Unit/Resource/UsersTest.php
@@ -411,7 +411,6 @@ class UsersTest extends TestCase
                 'realm' => 'test-realm',
                 'userId' => 'test-user-id',
             ],
-            contentType: ContentType::JSON,
         );
 
         $commandExecutor = $this->createMock(CommandExecutor::class);

--- a/tests/Unit/Resource/UsersTest.php
+++ b/tests/Unit/Resource/UsersTest.php
@@ -10,6 +10,7 @@ use Fschmtt\Keycloak\Collection\RoleCollection;
 use Fschmtt\Keycloak\Collection\UserCollection;
 use Fschmtt\Keycloak\Http\Command;
 use Fschmtt\Keycloak\Http\CommandExecutor;
+use Fschmtt\Keycloak\Http\ContentType;
 use Fschmtt\Keycloak\Http\Criteria;
 use Fschmtt\Keycloak\Http\Method;
 use Fschmtt\Keycloak\Http\Query;
@@ -410,6 +411,7 @@ class UsersTest extends TestCase
                 'realm' => 'test-realm',
                 'userId' => 'test-user-id',
             ],
+            contentType: ContentType::JSON,
         );
 
         $commandExecutor = $this->createMock(CommandExecutor::class);


### PR DESCRIPTION
Unfortunately the executeActionsEmail endpoint is not working right now as it does not comply with the Keycloak Api. This is because of the behaviour of the CommandExecutor which would use the application/x-www-form-urlencoded ContentType whenever only an array is defined as Payload. For the executeActionsEmail endpoint only an Array of Actions is required but Keycloak expects an application/json Content-Type. Therefore i added the (fully optional) possibility to specify the ContentType explicitly when creating the Command. By now i only updated the one Command with which i had issues - maybe this issues applies to some other endpoints as well.