### PR TITLE
feat: group by path endpoint and group members endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ $myCustomRepresentation = $myCustomResource->myCustomEndpoint();
 | `POST /admin/realms/{realm}/groups`               | `n/a`                                                 | [Groups::create()](src/Resource/Groups.php)   |
 | `POST /admin/realms/{realm}/groups/{id}/children` | `n/a`                                                 | [Groups::create()](src/Resource/Groups.php)   |
 | `DELETE /admin/realms/{realm}/groups`             | `n/a`                                                 | [Groups::delete()](src/Resource/Groups.php)   |
+| `GET /admin/realms/{realm}/group-by-path/{path}`  | [Group](src/Representation/Group.php)                 | [Groups::byPath()](src/Resource/Groups.php)   |
+
 
 ### [Realms Admin](https://www.keycloak.org/docs-api/26.0.0/rest-api/index.html#_realms_admin)
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ $myCustomRepresentation = $myCustomResource->myCustomEndpoint();
 |---------------------------------------------------|-------------------------------------------------------|-----------------------------------------------|
 | `GET /admin/realms/{realm}/groups`                | [GroupCollection](src/Collection/GroupCollection.php) | [Groups::all()](src/Resource/Groups.php)      |
 | `GET /admin/realms/{realm}/groups/{id}/children`  | [GroupCollection](src/Collection/GroupCollection.php) | [Groups::children()](src/Resource/Groups.php) |
+| `GET /admin/realms/{realm}/groups/{id}/members`   | [UserCollection](src/Collection/UserCollection.php)   | [Groups::members()](src/Resource/Groups.php)  |
 | `GET /admin/realms/{realm}/groups/{id}`           | [Group](src/Representation/Group.php)                 | [Groups::get()](src/Resource/Groups.php)      |
 | `PUT /admin/realms/{realm}/groups/{id}`           | `n/a`                                                 | [Groups::update()](src/Resource/Groups.php)   |
 | `POST /admin/realms/{realm}/groups`               | `n/a`                                                 | [Groups::create()](src/Resource/Groups.php)   |

--- a/src/Resource/Groups.php
+++ b/src/Resource/Groups.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fschmtt\Keycloak\Resource;
 
 use Fschmtt\Keycloak\Collection\GroupCollection;
+use Fschmtt\Keycloak\Collection\UserCollection;
 use Fschmtt\Keycloak\Http\Command;
 use Fschmtt\Keycloak\Http\Criteria;
 use Fschmtt\Keycloak\Http\Method;
@@ -36,7 +37,7 @@ class Groups extends Resource
                 [
                     'realm' => $realm,
                     'path' => $path,
-                ]    
+                ]
             )
         );
     }
@@ -47,6 +48,21 @@ class Groups extends Resource
             new Query(
                 '/admin/realms/{realm}/groups/{groupId}/children',
                 GroupCollection::class,
+                [
+                    'realm' => $realm,
+                    'groupId' => $groupId,
+                ],
+                $criteria
+            )
+        );
+    }
+
+    public function members(string $realm, string $groupId, ?Criteria $criteria = null): UserCollection
+    {
+        return $this->queryExecutor->executeQuery(
+            new Query(
+                '/admin/realms/{realm}/groups/{groupId}/members',
+                UserCollection::class,
                 [
                     'realm' => $realm,
                     'groupId' => $groupId,

--- a/src/Resource/Groups.php
+++ b/src/Resource/Groups.php
@@ -27,6 +27,20 @@ class Groups extends Resource
         );
     }
 
+    public function byPath(string $realm, string $path = ''): Group
+    {
+        return $this->queryExecutor->executeQuery(
+            new Query(
+                '/admin/realms/{realm}/group-by-path/{path}',
+                Group::class,
+                [
+                    'realm' => $realm,
+                    'path' => $path,
+                ]    
+            )
+        );
+    }
+
     public function children(string $realm, string $groupId, ?Criteria $criteria = null): GroupCollection
     {
         return $this->queryExecutor->executeQuery(

--- a/tests/Integration/Resource/GroupsTest.php
+++ b/tests/Integration/Resource/GroupsTest.php
@@ -77,5 +77,10 @@ class GroupsTest extends TestCase
         $childGroup = $childGroups->first();
         static::assertInstanceOf(Group::class, $childGroup);
         static::assertSame($childGroupName, $childGroup->getName());
+
+        // get child group by path
+        $pathGroup = $groups->byPath('master', $importedGroupName.'/'.$childGroupName);
+        static::assertInstanceOf(Group::class, $pathGroup);
+        static::assertSame($childGroup->getId(), $pathGroup->getId());
     }
 }

--- a/tests/Integration/Resource/UsersTest.php
+++ b/tests/Integration/Resource/UsersTest.php
@@ -91,6 +91,12 @@ class UsersTest extends TestCase
         static::assertInstanceOf(Group::class, $userFirstGroup);
         static::assertSame($group->getId(), $userFirstGroup->getId());
 
+        // get group members
+        $groupMembers = $groups->members('master', $group->getId());
+        static::assertSame(1, $groupMembers->count());
+        static::assertInstanceOf(User::class, $groupMembers->first());
+        static::assertSame($user->getId(), $groupMembers->first()->getId());
+
         // leave group
         $users->leaveGroup('master', $user->getId(), $group->getId());
 


### PR DESCRIPTION
Hi,
I came across the need to use the group by path and the group members endpoint. I mistakenly opened an issue for the group by path feature being missing from the all groups endpoint, since I overlooked the fact that it should be a separate endpoint.

Therefore, I created a pull request to implement the "GET /admin/realms/{realm}/groups/{group-id}/members" and the "GET /admin/realms/{realm}/group-by-path/{path}" endpoints.
Please let me know if there is anything I can improve on this pull request!