### PR TITLE
Feature/auth with service account

### DIFF
--- a/examples/attack-detection-clear-user.php
+++ b/examples/attack-detection-clear-user.php
@@ -3,15 +3,14 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $keycloak = new Keycloak(
-    $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    'admin',
-    'admin',
+    baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
+    grantType: new Password('admin', 'admin'),
 );
-
 $keycloak->attackDetection()->clearUser(
     realm: 'master',
     userId: 'afab8ba7-e278-4dda-8970-bd5a2a4c7bfb',

--- a/examples/attack-detection-clear.php
+++ b/examples/attack-detection-clear.php
@@ -3,13 +3,13 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $keycloak = new Keycloak(
-    $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    'admin',
-    'admin',
+    baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
+    grantType: new Password('admin', 'admin'),
 );
 
 $keycloak->attackDetection()->clear(

--- a/examples/attack-detection-user-status.php
+++ b/examples/attack-detection-user-status.php
@@ -3,13 +3,13 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $keycloak = new Keycloak(
-    $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    'admin',
-    'admin',
+    baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
+    grantType: new Password('admin', 'admin'),
 );
 
 $userStatus = $keycloak->attackDetection()->userStatus(

--- a/examples/clients-all.php
+++ b/examples/clients-all.php
@@ -3,15 +3,14 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $keycloak = new Keycloak(
     baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    username: 'admin',
-    password: 'admin',
+    grantType: new Password('admin', 'admin'),
 );
-
 $realm = $keycloak->realms()->get('master');
 
 $resource = $keycloak->clients();

--- a/examples/clients-get.php
+++ b/examples/clients-get.php
@@ -3,13 +3,13 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $keycloak = new Keycloak(
     baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    username: 'admin',
-    password: 'admin',
+    grantType: new Password('admin', 'admin'),
 );
 
 $resource = $keycloak->clients();

--- a/examples/clients-import.php
+++ b/examples/clients-import.php
@@ -3,14 +3,14 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 use Ramsey\Uuid\Uuid;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $keycloak = new Keycloak(
     baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    username: 'admin',
-    password: 'admin',
+    grantType: new Password('admin', 'admin'),
 );
 
 $resource = $keycloak->clients();

--- a/examples/custom-resource.php
+++ b/examples/custom-resource.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 
 /**
  * @method string|null getId()
@@ -32,9 +33,8 @@ class MyCustomResource extends \Fschmtt\Keycloak\Resource\Resource
 }
 
 $keycloak = new Keycloak(
-    $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    'admin',
-    'admin',
+    baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
+    grantType: new Password('admin', 'admin'),
 );
 
 /** @var MyCustomResource $myCustomResource */

--- a/examples/groups-all.php
+++ b/examples/groups-all.php
@@ -3,14 +3,14 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 use Fschmtt\Keycloak\Representation\Group;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $keycloak = new Keycloak(
     baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    username: 'admin',
-    password: 'admin',
+    grantType: new Password('admin', 'admin'),
 );
 
 $realm = 'master';

--- a/examples/realms-admin-events.php
+++ b/examples/realms-admin-events.php
@@ -3,13 +3,13 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $keycloak = new Keycloak(
     baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    username: 'admin',
-    password: 'admin',
+    grantType: new Password('admin', 'admin'),
 );
 
 $realm = $keycloak->realms()->get('master');

--- a/examples/realms-all.php
+++ b/examples/realms-all.php
@@ -3,13 +3,13 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $keycloak = new Keycloak(
     baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    username: 'admin',
-    password: 'admin',
+    grantType: new Password('admin', 'admin'),
 );
 
 $realms = $keycloak->realms()->all();

--- a/examples/realms-delete.php
+++ b/examples/realms-delete.php
@@ -3,14 +3,14 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 use Fschmtt\Keycloak\Representation\Realm;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $keycloak = new Keycloak(
     baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    username: 'admin',
-    password: 'admin',
+    grantType: new Password('admin', 'admin'),
 );
 
 $random = bin2hex(random_bytes(length: 8));

--- a/examples/realms-import.php
+++ b/examples/realms-import.php
@@ -3,14 +3,14 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 use Fschmtt\Keycloak\Representation\Realm;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $keycloak = new Keycloak(
     baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    username: 'admin',
-    password: 'admin',
+    grantType: new Password('admin', 'admin'),
 );
 
 $random = bin2hex(random_bytes(length: 8));

--- a/examples/realms-update.php
+++ b/examples/realms-update.php
@@ -3,13 +3,13 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $keycloak = new Keycloak(
     baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    username: 'admin',
-    password: 'admin',
+    grantType: new Password('admin', 'admin'),
 );
 
 // Fetch realm

--- a/examples/serverinfo.php
+++ b/examples/serverinfo.php
@@ -3,13 +3,13 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $keycloak = new Keycloak(
-    $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    'admin',
-    'admin',
+    baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
+    grantType: new Password('admin', 'admin'),
 );
 
 $serverInfo = $keycloak->serverInfo()->get();

--- a/examples/users-all.php
+++ b/examples/users-all.php
@@ -3,13 +3,13 @@
 declare(strict_types=1);
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $keycloak = new Keycloak(
     baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-    username: 'admin',
-    password: 'admin',
+    grantType: new Password('admin', 'admin'),
 );
 
 $realm = 'master';

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -6,6 +6,7 @@ namespace Fschmtt\Keycloak\Http;
 
 use DateTime;
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantTypeInterface;
 use Fschmtt\Keycloak\OAuth\TokenStorageInterface;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
@@ -22,6 +23,7 @@ class Client
         private readonly Keycloak $keycloak,
         private readonly ClientInterface $httpClient,
         private readonly TokenStorageInterface $tokenStorage,
+        private readonly GrantTypeInterface $grantType,
     ) {}
 
     /**
@@ -73,11 +75,9 @@ class Client
                 'POST',
                 $this->keycloak->getBaseUrl() . '/realms/master/protocol/openid-connect/token',
                 [
-                    'form_params' => [
-                        'refresh_token' => $this->tokenStorage->retrieveRefreshToken()?->toString(),
-                        'client_id' => 'admin-cli',
-                        'grant_type' => 'refresh_token',
-                    ],
+                    'form_params' => $this->grantType->getRefreshTokenFormParams(
+                        $this->tokenStorage->retrieveRefreshToken()?->toString(),
+                    ),
                 ],
             );
         } catch (ClientException $e) {
@@ -85,12 +85,7 @@ class Client
                 'POST',
                 $this->keycloak->getBaseUrl() . '/realms/master/protocol/openid-connect/token',
                 [
-                    'form_params' => [
-                        'username' => $this->keycloak->getUsername(),
-                        'password' => $this->keycloak->getPassword(),
-                        'client_id' => 'admin-cli',
-                        'grant_type' => 'password',
-                    ],
+                    'form_params' => $this->grantType->getFetchTokenFormParams(),
                 ],
             );
         }

--- a/src/OAuth/GrantType/ClientCredentials.php
+++ b/src/OAuth/GrantType/ClientCredentials.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fschmtt\Keycloak\OAuth\GrantType;
+
+use Fschmtt\Keycloak\OAuth\GrantTypeInterface;
+
+class ClientCredentials implements GrantTypeInterface
+{
+    public function __construct(
+        private readonly string $clientId,
+        private readonly string $clientSecret,
+    ) {}
+
+    public function getFetchTokenFormParams(): array
+    {
+        return [
+            'grant_type' => 'client_credentials',
+            'client_id' => $this->clientId,
+            'client_secret' => $this->clientSecret,
+        ];
+    }
+
+    public function getRefreshTokenFormParams(?string $refreshToken): array
+    {
+        // client_credentials tokens cannot be refreshed, but you could return an empty array or throw an exception.
+        return [];
+    }
+}

--- a/src/OAuth/GrantType/Password.php
+++ b/src/OAuth/GrantType/Password.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fschmtt\Keycloak\OAuth\GrantType;
+
+use Fschmtt\Keycloak\OAuth\GrantTypeInterface;
+
+class Password implements GrantTypeInterface
+{
+    public function __construct(
+        private readonly string $username,
+        private readonly string $password,
+        private readonly string $clientId = 'admin-cli',
+    ) {}
+
+    public function getFetchTokenFormParams(): array
+    {
+        return [
+            'grant_type' => 'password',
+            'username' => $this->username,
+            'password' => $this->password,
+            'client_id' => $this->clientId,
+        ];
+    }
+
+    public function getRefreshTokenFormParams(?string $refreshToken): array
+    {
+        return [
+            'refresh_token' => $refreshToken,
+            'grant_type' => 'refresh_token',
+            'client_id' => $this->clientId,
+        ];
+    }
+}

--- a/src/OAuth/GrantTypeInterface.php
+++ b/src/OAuth/GrantTypeInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Fschmtt\Keycloak\OAuth;
+
+interface GrantTypeInterface
+{
+    /**
+     * Returns form parameters for fetching an access token.
+     *
+     * @return array<string, string>
+     */
+    public function getFetchTokenFormParams(): array;
+
+    /**
+     * Returns form parameters for refreshing an access token.
+     *
+     * @param string|null $refreshToken
+     * @return array<string, string>
+     */
+    public function getRefreshTokenFormParams(?string $refreshToken): array;
+}

--- a/tests/Integration/IntegrationTestBehaviour.php
+++ b/tests/Integration/IntegrationTestBehaviour.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fschmtt\Keycloak\Test\Integration;
 
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 
 trait IntegrationTestBehaviour
 {
@@ -14,9 +15,8 @@ trait IntegrationTestBehaviour
     {
         if (!$this->keycloak) {
             $this->keycloak = new Keycloak(
-                $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
-                'admin',
-                'admin',
+                baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
+                grantType: new Password('admin', 'admin'),
             );
         }
 

--- a/tests/Unit/Http/ClientTest.php
+++ b/tests/Unit/Http/ClientTest.php
@@ -7,6 +7,7 @@ namespace Fschmtt\Keycloak\Test\Unit\Http;
 use DateTimeImmutable;
 use Fschmtt\Keycloak\Http\Client;
 use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
 use Fschmtt\Keycloak\OAuth\TokenStorage\InMemory as InMemoryTokenStorage;
 use Fschmtt\Keycloak\Test\Unit\TokenGenerator;
 use GuzzleHttp\ClientInterface;
@@ -25,9 +26,8 @@ class ClientTest extends TestCase
     protected function setUp(): void
     {
         $this->keycloak = new Keycloak(
-            'http://keycloak:8080',
-            'admin',
-            'admin',
+            baseUrl: 'http://keycloak:8080',
+            grantType: new Password('admin', 'admin'),
         );
     }
 
@@ -66,7 +66,12 @@ class ClientTest extends TestCase
                 $realmsResponse,
             );
 
-        $client = new Client($this->keycloak, $httpClient, new InMemoryTokenStorage());
+        $client = new Client(
+            $this->keycloak,
+            $httpClient,
+            new InMemoryTokenStorage(),
+            new Password('admin', 'admin'),
+        );
         $client->request('GET', '/admin/realms');
 
         static::assertTrue($client->isAuthorized());
@@ -78,6 +83,7 @@ class ClientTest extends TestCase
             $this->keycloak,
             $this->createMock(ClientInterface::class),
             new InMemoryTokenStorage(),
+            new Password('admin', 'admin'),
         );
 
         static::assertFalse($client->isAuthorized());
@@ -94,6 +100,7 @@ class ClientTest extends TestCase
             $this->keycloak,
             $this->createMock(ClientInterface::class),
             $tokenStorage,
+            new Password('admin', 'admin'),
         );
 
         static::assertFalse($client->isAuthorized());
@@ -110,6 +117,7 @@ class ClientTest extends TestCase
             $this->keycloak,
             $this->createMock(ClientInterface::class),
             $tokenStorage,
+            new Password('admin', 'admin'),
         );
 
         static::assertTrue($client->isAuthorized());

--- a/tests/Unit/OAuth/GrantType/ClientCredentialsTest.php
+++ b/tests/Unit/OAuth/GrantType/ClientCredentialsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Fschmtt\Keycloak\Test\Unit\OAuth\GrantType;
+
+use Fschmtt\Keycloak\OAuth\GrantType\ClientCredentials;
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ClientCredentials::class)]
+class ClientCredentialsTest extends TestCase
+{
+    public function testGetFetchTokenFormParams(): void
+    {
+        $clientCredentials = new ClientCredentials('clientId', 'clientSecret');
+        $params = $clientCredentials->getFetchTokenFormParams();
+
+        static::assertSame(
+            [
+                'grant_type' => 'client_credentials',
+                'client_id' => 'clientId',
+                'client_secret' => 'clientSecret',
+            ],
+            $params,
+        );
+    }
+
+    public function testGetRefreshTokenFormParams(): void
+    {
+        $clientCredentials = new ClientCredentials('clientId', 'clientSecret');
+        $params = $clientCredentials->getRefreshTokenFormParams('refreshToken');
+
+        static::assertSame(
+            [],
+            $params,
+        );
+    }
+}

--- a/tests/Unit/OAuth/GrantType/PasswordTest.php
+++ b/tests/Unit/OAuth/GrantType/PasswordTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Fschmtt\Keycloak\Test\Unit\OAuth\GrantType;
+
+use Fschmtt\Keycloak\OAuth\GrantType\Password;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Password::class)]
+class PasswordTest extends TestCase
+{
+    public function testGetFetchTokenFormParams(): void
+    {
+        $passwordGrant = new Password('admin', 'admin', 'admin-cli');
+        $params = $passwordGrant->getFetchTokenFormParams();
+
+        static::assertSame(
+            [
+                'grant_type' => 'password',
+                'username' => 'admin',
+                'password' => 'admin',
+                'client_id' => 'admin-cli',
+            ],
+            $params,
+        );
+    }
+
+    public function testGetRefreshTokenFormParams(): void
+    {
+        $passwordGrant = new Password('admin', 'admin', 'admin-cli');
+        $params = $passwordGrant->getRefreshTokenFormParams('refreshToken');
+
+        static::assertSame(
+            [
+                'refresh_token' => 'refreshToken',
+                'grant_type' => 'refresh_token',
+                'client_id' => 'admin-cli',
+            ],
+            $params,
+        );
+    }
+}


### PR DESCRIPTION
Introduce a `GrantTypeInterface` and implement `Password` and `ClientCredentials` grant types. Deprecated `$username` and `$password` parameters in favor of the new `GrantTypeInterface` approach.