### PR TITLE
feat: Add `all()` to collection

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -82,4 +82,12 @@ abstract class Collection implements Countable, IteratorAggregate, JsonSerializa
     {
         return $this->items[0] ?? null;
     }
+
+    /**
+     * @return array<array-key, T>
+     */
+    public function all(): array
+    {
+        return $this->items;
+    }
 }


### PR DESCRIPTION
Thank you for creating this great package. While using it, I noticed that the `Collection` class could be further optimized by adding an `all` method (or `getItems`). Although the `getIterator` method is already available, which allows us to use `foreach` to access the items, it isn’t as convenient. For example, it doesn’t support functions like `array_map`:

```php
// This doesn't work
return array_map(fn($item) => new TeamResource($item), $groupCollection);
```

I’m using Laravel, and my current approach looks like this:

```php
$teams = [];

foreach($groupCollection as $group) {
    $teams[] = $group;
}

return TeamResource::collection($teams);
```

If possible, I would like to be able to do this instead:

```php
return TeamResource::collection($groupCollection->all());
```

Thanks!