### PR TITLE
feat: Refactor CommandExecutor and Resource Handling: Standardize Response Types and Add Examples

### DIFF
--- a/examples/groups-create.php
+++ b/examples/groups-create.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\Representation\Group;
+use Fschmtt\Keycloak\Representation\User;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$keycloak = new Keycloak(
+    baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
+    username: 'admin',
+    password: 'admin',
+);
+
+$realm = 'master';
+
+$group = new Group(
+    name: 'foo',
+);
+
+$response = $keycloak->groups()->create($realm, $group);
+
+var_dump($response);

--- a/examples/organizations-create.php
+++ b/examples/organizations-create.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Fschmtt\Keycloak\Collection\OrganizationDomainCollection;
+use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\Representation\OrganizationDomain;
+use Fschmtt\Keycloak\Representation\Realm;
+use Fschmtt\Keycloak\Representation\Organization;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$keycloak = new Keycloak(
+    baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
+    username: 'admin',
+    password: 'admin',
+);
+
+$realm = 'master';
+
+// enable organizations
+$keycloak->realms()->update($realm, (new Realm(realm: $realm))->withOrganizationsEnabled(true));
+
+$organization = new Organization(
+    name: 'My-Organization',
+    domains: new OrganizationDomainCollection([
+        new OrganizationDomain('example.com'),
+    ]),
+);
+
+$response = $keycloak->organizations()->create($realm, $organization);
+
+var_dump($response);

--- a/examples/roles-create.php
+++ b/examples/roles-create.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Fschmtt\Keycloak\Collection\OrganizationDomainCollection;
+use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\Representation\OrganizationDomain;
+use Fschmtt\Keycloak\Representation\Realm;
+use Fschmtt\Keycloak\Representation\Organization;
+use Fschmtt\Keycloak\Representation\Role;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$keycloak = new Keycloak(
+    baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
+    username: 'admin',
+    password: 'admin',
+);
+
+$realm = 'master';
+
+$role = new Role(
+    name: 'my-role',
+);
+
+$response = $keycloak->roles()->create($realm, $role);
+
+var_dump($response);

--- a/examples/users-create.php
+++ b/examples/users-create.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Fschmtt\Keycloak\Keycloak;
+use Fschmtt\Keycloak\Representation\User;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$keycloak = new Keycloak(
+    baseUrl: $_SERVER['KEYCLOAK_BASE_URL'] ?? 'http://keycloak:8080',
+    username: 'admin',
+    password: 'admin',
+);
+
+$realm = 'master';
+
+$user = new User(
+    email: 'foo@example.com',
+    username: 'foo',
+);
+
+$response = $keycloak->users()->create($realm, $user);
+
+var_dump($response);

--- a/src/Http/CommandExecutor.php
+++ b/src/Http/CommandExecutor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fschmtt\Keycloak\Http;
 
 use Fschmtt\Keycloak\Serializer\Serializer;
+use Psr\Http\Message\ResponseInterface;
 
 use function is_array;
 
@@ -18,7 +19,7 @@ class CommandExecutor
         private readonly Serializer $serializer,
     ) {}
 
-    public function executeCommand(Command $command): void
+    public function executeCommand(Command $command): ResponseInterface
     {
         $options = match ($command->getContentType()) {
             ContentType::JSON => [
@@ -30,10 +31,6 @@ class CommandExecutor
             ContentType::FORM_PARAMS => ['form_params' => $command->getPayload()],
         };
 
-        $this->client->request(
-            $command->getMethod()->value,
-            $command->getPath(),
-            $options,
-        );
+        return $this->client->request($command->getMethod()->value, $command->getPath(), $options);
     }
 }

--- a/src/Resource/AttackDetection.php
+++ b/src/Resource/AttackDetection.php
@@ -8,12 +8,13 @@ use Fschmtt\Keycloak\Http\Command;
 use Fschmtt\Keycloak\Http\Method;
 use Fschmtt\Keycloak\Http\Query;
 use Fschmtt\Keycloak\Type\Map;
+use Psr\Http\Message\ResponseInterface;
 
 class AttackDetection extends Resource
 {
-    public function clear(string $realm): void
+    public function clear(string $realm): ResponseInterface
     {
-        $this->commandExecutor->executeCommand(
+        return $this->commandExecutor->executeCommand(
             new Command(
                 '/admin/realms/{realm}/attack-detection/brute-force/users',
                 Method::DELETE,

--- a/src/Resource/Clients.php
+++ b/src/Resource/Clients.php
@@ -11,6 +11,7 @@ use Fschmtt\Keycloak\Http\Method;
 use Fschmtt\Keycloak\Http\Query;
 use Fschmtt\Keycloak\Representation\Client as ClientRepresentation;
 use Fschmtt\Keycloak\Representation\Credential;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @phpstan-type UserSession array<mixed>
@@ -78,9 +79,9 @@ class Clients extends Resource
         return $this->get($realm, $updatedClient->getId());
     }
 
-    public function delete(string $realm, string $clientUuid): void
+    public function delete(string $realm, string $clientUuid): ResponseInterface
     {
-        $this->commandExecutor->executeCommand(
+        return $this->commandExecutor->executeCommand(
             new Command(
                 '/admin/realms/{realm}/clients/{clientUuid}',
                 Method::DELETE,

--- a/src/Resource/Realms.php
+++ b/src/Resource/Realms.php
@@ -11,6 +11,7 @@ use Fschmtt\Keycloak\Http\Method;
 use Fschmtt\Keycloak\Http\Query;
 use Fschmtt\Keycloak\Representation\KeysMetadata;
 use Fschmtt\Keycloak\Representation\Realm;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * @phpstan-type AdminEvent array<mixed>
@@ -70,9 +71,9 @@ class Realms extends Resource
         return $this->get($updatedRealm->getRealm());
     }
 
-    public function delete(string $realm): void
+    public function delete(string $realm): ResponseInterface
     {
-        $this->commandExecutor->executeCommand(
+        return $this->commandExecutor->executeCommand(
             new Command(
                 '/admin/realms/{realm}',
                 Method::DELETE,
@@ -114,9 +115,9 @@ class Realms extends Resource
         );
     }
 
-    public function deleteAdminEvents(string $realm): void
+    public function deleteAdminEvents(string $realm): ResponseInterface
     {
-        $this->commandExecutor->executeCommand(
+        return $this->commandExecutor->executeCommand(
             new Command(
                 '/admin/realms/{realm}/admin-events',
                 Method::DELETE,
@@ -127,9 +128,9 @@ class Realms extends Resource
         );
     }
 
-    public function clearKeysCache(string $realm): void
+    public function clearKeysCache(string $realm): ResponseInterface
     {
-        $this->commandExecutor->executeCommand(
+        return $this->commandExecutor->executeCommand(
             new Command(
                 '/admin/realms/{realm}/clear-keys-cache',
                 Method::POST,
@@ -140,9 +141,9 @@ class Realms extends Resource
         );
     }
 
-    public function clearRealmCache(string $realm): void
+    public function clearRealmCache(string $realm): ResponseInterface
     {
-        $this->commandExecutor->executeCommand(
+        return $this->commandExecutor->executeCommand(
             new Command(
                 '/admin/realms/{realm}/clear-realm-cache',
                 Method::POST,
@@ -153,9 +154,9 @@ class Realms extends Resource
         );
     }
 
-    public function clearUserCache(string $realm): void
+    public function clearUserCache(string $realm): ResponseInterface
     {
-        $this->commandExecutor->executeCommand(
+        return $this->commandExecutor->executeCommand(
             new Command(
                 '/admin/realms/{realm}/clear-user-cache',
                 Method::POST,

--- a/src/Resource/Roles.php
+++ b/src/Resource/Roles.php
@@ -10,6 +10,7 @@ use Fschmtt\Keycloak\Http\Criteria;
 use Fschmtt\Keycloak\Http\Method;
 use Fschmtt\Keycloak\Http\Query;
 use Fschmtt\Keycloak\Representation\Role;
+use Psr\Http\Message\ResponseInterface;
 
 class Roles extends Resource
 {
@@ -41,7 +42,7 @@ class Roles extends Resource
         );
     }
 
-    public function create(string $realm, Role $role): void
+    public function create(string $realm, Role $role): Role
     {
         $this->commandExecutor->executeCommand(
             new Command(
@@ -53,11 +54,13 @@ class Roles extends Resource
                 $role,
             ),
         );
+
+        return $this->get($realm, $role->getName());
     }
 
-    public function delete(string $realm, string $roleName): void
+    public function delete(string $realm, string $roleName): ResponseInterface
     {
-        $this->commandExecutor->executeCommand(
+        return $this->commandExecutor->executeCommand(
             new Command(
                 '/admin/realms/{realm}/roles/{roleName}',
                 Method::DELETE,
@@ -69,7 +72,7 @@ class Roles extends Resource
         );
     }
 
-    public function update(string $realm, Role $role): void
+    public function update(string $realm, Role $role): Role
     {
         $this->commandExecutor->executeCommand(
             new Command(
@@ -82,5 +85,7 @@ class Roles extends Resource
                 $role,
             ),
         );
+
+        return $this->get($realm, $role->getName());
     }
 }

--- a/tests/Unit/Resource/ClientsTest.php
+++ b/tests/Unit/Resource/ClientsTest.php
@@ -13,6 +13,7 @@ use Fschmtt\Keycloak\Http\QueryExecutor;
 use Fschmtt\Keycloak\Representation\Client as ClientRepresentation;
 use Fschmtt\Keycloak\Representation\Credential;
 use Fschmtt\Keycloak\Resource\Clients;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -199,14 +200,17 @@ class ClientsTest extends TestCase
         $commandExecutor = $this->createMock(CommandExecutor::class);
         $commandExecutor->expects(static::once())
             ->method('executeCommand')
-            ->with($command);
+            ->with($command)
+            ->willReturn(new Response(204));
 
         $clients = new Clients(
             $commandExecutor,
             $this->createMock(QueryExecutor::class),
         );
 
-        $clients->delete('test-realm', $deletedClientId);
+        $response = $clients->delete('test-realm', $deletedClientId);
+
+        static::assertSame(204, $response->getStatusCode());
     }
 
     public function testGetUserSessions(): void

--- a/tests/Unit/Resource/RealmsTest.php
+++ b/tests/Unit/Resource/RealmsTest.php
@@ -13,6 +13,7 @@ use Fschmtt\Keycloak\Http\QueryExecutor;
 use Fschmtt\Keycloak\Representation\KeysMetadata;
 use Fschmtt\Keycloak\Representation\Realm;
 use Fschmtt\Keycloak\Resource\Realms;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -145,13 +146,17 @@ class RealmsTest extends TestCase
         $commandExecutor = $this->createMock(CommandExecutor::class);
         $commandExecutor->expects(static::once())
             ->method('executeCommand')
-            ->with($command);
+            ->with($command)
+            ->willReturn(new Response(204));
 
         $realms = new Realms(
             $commandExecutor,
             $this->createMock(QueryExecutor::class),
         );
-        $realms->delete('to-be-deleted-realm');
+
+        $response = $realms->delete('to-be-deleted-realm');
+
+        static::assertSame(204, $response->getStatusCode());
     }
 
     public function testGetAdminEvents(): void
@@ -194,13 +199,17 @@ class RealmsTest extends TestCase
         $commandExecutor = $this->createMock(CommandExecutor::class);
         $commandExecutor->expects(static::once())
             ->method('executeCommand')
-            ->with($command);
+            ->with($command)
+            ->willReturn(new Response(204));
 
         $realms = new Realms(
             $commandExecutor,
             $this->createMock(QueryExecutor::class),
         );
-        $realms->deleteAdminEvents('realm-with-admin-events');
+
+        $response = $realms->deleteAdminEvents('realm-with-admin-events');
+
+        static::assertSame(204, $response->getStatusCode());
     }
 
     public function testClearKeysCache(): void
@@ -216,13 +225,17 @@ class RealmsTest extends TestCase
         $commandExecutor = $this->createMock(CommandExecutor::class);
         $commandExecutor->expects(static::once())
             ->method('executeCommand')
-            ->with($command);
+            ->with($command)
+            ->willReturn(new Response(204));
 
         $realms = new Realms(
             $commandExecutor,
             $this->createMock(QueryExecutor::class),
         );
-        $realms->clearKeysCache('realm-with-cache');
+
+        $response = $realms->clearKeysCache('realm-with-cache');
+
+        static::assertSame(204, $response->getStatusCode());
     }
 
     public function testClearRealmCache(): void
@@ -238,13 +251,17 @@ class RealmsTest extends TestCase
         $commandExecutor = $this->createMock(CommandExecutor::class);
         $commandExecutor->expects(static::once())
             ->method('executeCommand')
-            ->with($command);
+            ->with($command)
+            ->willReturn(new Response(204));
 
         $realms = new Realms(
             $commandExecutor,
             $this->createMock(QueryExecutor::class),
         );
-        $realms->clearRealmCache('realm-with-cache');
+
+        $response = $realms->clearRealmCache('realm-with-cache');
+
+        static::assertSame(204, $response->getStatusCode());
     }
 
     public function testClearUserCache(): void
@@ -260,13 +277,17 @@ class RealmsTest extends TestCase
         $commandExecutor = $this->createMock(CommandExecutor::class);
         $commandExecutor->expects(static::once())
             ->method('executeCommand')
-            ->with($command);
+            ->with($command)
+            ->willReturn(new Response(204));
 
         $realms = new Realms(
             $commandExecutor,
             $this->createMock(QueryExecutor::class),
         );
-        $realms->clearUserCache('realm-with-cache');
+
+        $response = $realms->clearUserCache('realm-with-cache');
+
+        static::assertSame(204, $response->getStatusCode());
     }
 
     public function testGetKeys(): void
@@ -290,6 +311,8 @@ class RealmsTest extends TestCase
             $queryExecutor,
         );
 
-        $realms->keys('realm-with-keys');
+        $keys = $realms->keys('realm-with-keys');
+
+        static::assertInstanceOf(KeysMetadata::class, $keys);
     }
 }


### PR DESCRIPTION
Hi, @fschmtt  I’ve made some user-friendly changes, of course, this is part of my work. If everything is okay, I will be submitting other PRs in the next few days. Below are the details of this change:

1. `CommandExecutor::executeCommand` now returns ResponseInterface by default.
2. The create and update actions of Resource return Representation.
3. Other write operations on Resource return a ResponseInterface object when there is no return value.
4. Added several examples.

Thanks.