### PR TITLE
Fix Keycloak BadRequestException due to unrecognized field "flowId"

### DIFF
--- a/src/Representation/AuthenticationExecutionExport.php
+++ b/src/Representation/AuthenticationExecutionExport.php
@@ -36,6 +36,6 @@ class AuthenticationExecutionExport extends Representation
         protected ?string $flowAlias = null,
         protected ?int $priority = null,
         protected ?string $requirement = null,
-        protected ?bool $userSetupAllowed = null
+        protected ?bool $userSetupAllowed = null,
     ) {}
 }

--- a/src/Representation/AuthenticationExecutionExport.php
+++ b/src/Representation/AuthenticationExecutionExport.php
@@ -14,14 +14,8 @@ namespace Fschmtt\Keycloak\Representation;
  * @method bool|null getAuthenticatorFlow()
  * @method self withAuthenticatorFlow(?bool $authenticatorFlow)
  *
- * @method string|null getFlowId()
- * @method self withFlowId(?string $flowId)
- *
- * @method string|null getId()
- * @method self withId(?string $id)
- *
- * @method string|null getParentFlow()
- * @method self withParentFlow(?string $parentFlow)
+ * @method string|null getFlowAlias()
+ * @method self withFlowAlias(?string $flowAlias)
  *
  * @method int|null getPriority()
  * @method self withPriority(?int $priority)
@@ -29,6 +23,8 @@ namespace Fschmtt\Keycloak\Representation;
  * @method string|null getRequirement()
  * @method self withRequirement(?string $requirement)
  *
+ * @method bool|null getUserSetupAllowed()
+ * @method self withUserSetupAllowed(?bool $userSetupAllowed)
  * @codeCoverageIgnore
  */
 class AuthenticationExecutionExport extends Representation
@@ -37,10 +33,9 @@ class AuthenticationExecutionExport extends Representation
         protected ?string $authenticator = null,
         protected ?string $authenticatorConfig = null,
         protected ?bool $authenticatorFlow = null,
-        protected ?string $flowId = null,
-        protected ?string $id = null,
-        protected ?string $parentFlow = null,
+        protected ?string $flowAlias = null,
         protected ?int $priority = null,
         protected ?string $requirement = null,
+        protected ?bool $userSetupAllowed = null
     ) {}
 }


### PR DESCRIPTION
The Keycloak API returned a 400 BadRequestException because the field "flowId"  was not recognized in AuthenticationExecutionExportRepresentation. 

This issue occurred due to an unexpected property in the exported authentication  flow configuration. 

To fix this:
- The "flowId" field has been removed/updated to align with the expected  Keycloak data structure.
- The change ensures proper compatibility with the Keycloak API and prevents  errors during authentication flow import/export.

This fix prevents Keycloak from rejecting authentication flow configurations  due to unrecognized properties.

2025-03-18 11:12:26,657 DEBUG [org.keycloak.services.error.KeycloakErrorHandler] (executor-thread-176) Error response 400: jakarta.ws.rs.BadRequestException: Unrecognized field "flowId" (class org.keycloak.representations.idm.AuthenticationExecutionExportRepresentation), not marked as ignorable (8 known properties: "authenticatorFlow", "flowAlias", "authenticator", "priority", "authenticatorConfig", "userSetupAllowed", "requirement", "autheticatorFlow"])
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 787] (through reference chain: org.keycloak.representations.idm.RealmRepresentation["authenticationFlows"]->java.util.ArrayList[0]->org.keycloak.representations.idm.AuthenticationFlowRepresentation["authenticationExecutions"]->java.util.ArrayList[0]->org.keycloak.representations.idm.AuthenticationExecutionExportRepresentation["flowId"])