### PR TITLE
Fix: Allow custom resources to use Method enum despite @internal rest…

### DIFF
--- a/src/Http/Method.php
+++ b/src/Http/Method.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Fschmtt\Keycloak\Http;
 
-/**
- * @internal
- */
 enum Method: string
 {
     case GET = 'GET';


### PR DESCRIPTION
…riction

The `Method` enum is marked as `@internal`, which prevents its usage in custom resource instantiations that require it as a constructor argument for `Command`.  

This commit addresses the issue by either:  
- Removing or modifying the `@internal` annotation from `Method`, making it accessible for external usage.  
- Providing an alternative approach to allow custom resources to define HTTP methods without direct reliance on the internal enum.  

This change ensures better extensibility while maintaining the integrity of the existing architecture.