### PR TITLE
fix: allow payload to be a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $myCustomRepresentation = $myCustomResource->myCustomEndpoint();
 ### [Attack Detection](https://www.keycloak.org/docs-api/26.0.0/rest-api/index.html#_attack_detection)
 
 | Endpoint                                                                   | Response                | API                                                               |
-| -------------------------------------------------------------------------- | ----------------------- | ----------------------------------------------------------------- |
+|----------------------------------------------------------------------------|-------------------------|-------------------------------------------------------------------|
 | `DELETE /admin/realms/{realm}/attack-detection/brute-force/users`          | `n/a`                   | [AttackDetection::clear()](src/Resource/AttackDetection.php)      |
 | `GET /admin/realms/{realm}/attack-detection/brute-force/users/{userId}`    | [Map](src/Type/Map.php) | [AttackDetection::userStatus()](src/Resource/AttackDetection.php) |
 | `DELETE /admin/realms/{realm}/attack-detection/brute-force/users/{userId}` | `n/a`                   | [AttackDetection::clearUser()](src/Resource/AttackDetection.php)  |
@@ -114,7 +114,7 @@ $myCustomRepresentation = $myCustomResource->myCustomEndpoint();
 ### [Clients](https://www.keycloak.org/docs-api/26.0.0/rest-api/index.html#_clients)
 
 | Endpoint                                                       | Response                                                | API                                                    |
-| -------------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------ |
+|----------------------------------------------------------------|---------------------------------------------------------|--------------------------------------------------------|
 | `GET /admin/realms/{realm}/clients`                            | [ClientCollection](src/Collection/ClientCollection.php) | [Clients::all()](src/Resource/Clients.php)             |
 | `GET /admin/realms/{realm}/clients/{client-uuid}`              | [Client](src/Representation/Client.php)                 | [Clients::get()](src/Resource/Clients.php)             |
 | `PUT /admin/realms/{realm}/clients/{client-uuid}`              | [Client](src/Representation/Client.php)                 | [Clients::update()](src/Resource/Clients.php)          |
@@ -124,7 +124,7 @@ $myCustomRepresentation = $myCustomResource->myCustomEndpoint();
 ### [Groups](https://www.keycloak.org/docs-api/26.0.0/rest-api/index.html#_clients)
 
 | Endpoint                                          | Response                                              | API                                           |
-| ------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------- |
+|---------------------------------------------------|-------------------------------------------------------|-----------------------------------------------|
 | `GET /admin/realms/{realm}/groups`                | [GroupCollection](src/Collection/GroupCollection.php) | [Groups::all()](src/Resource/Groups.php)      |
 | `GET /admin/realms/{realm}/groups/{id}/children`  | [GroupCollection](src/Collection/GroupCollection.php) | [Groups::children()](src/Resource/Groups.php) |
 | `GET /admin/realms/{realm}/groups/{id}/members`   | [UserCollection](src/Collection/UserCollection.php)   | [Groups::members()](src/Resource/Groups.php)  |
@@ -135,21 +135,21 @@ $myCustomRepresentation = $myCustomResource->myCustomEndpoint();
 | `DELETE /admin/realms/{realm}/groups`             | `n/a`                                                 | [Groups::delete()](src/Resource/Groups.php)   |
 | `GET /admin/realms/{realm}/group-by-path/{path}`  | [Group](src/Representation/Group.php)                 | [Groups::byPath()](src/Resource/Groups.php)   |
 
-
 ### [Organizations](https://www.keycloak.org/docs-api/26.0.0/rest-api/index.html#_organizations)
 
 | Endpoint                                                            | Response                                                            | API                                                           |
-| ------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------- |
+|---------------------------------------------------------------------|---------------------------------------------------------------------|---------------------------------------------------------------|
 | `GET /admin/realms/{realm}/organizations`                           | [OrganizationCollection](src/Collection/OrganizationCollection.php) | [Organizations::all()](src/Resource/Organizations.php)        |
 | `GET /admin/realms/{realm}/organizations/{id}`                      | [Organization](src/Representation/Organization.php)                 | [Organizations::get()](src/Resource/Organizations.php)        |
 | `POST /admin/realms/{realm}/organizations`                          | `n/a`                                                               | [Organizations::create()](src/Resource/Organizations.php)     |
 | `DELETE /admin/realms/{realm}/organizations/{id}`                   | `n/a`                                                               | [Organizations::delete()](src/Resource/Organizations.php)     |
 | `POST /admin/realms/{realm}/organizations/{id}/members/invite-user` | `n/a`                                                               | [Organizations::inviteUser()](src/Resource/Organizations.php) |
+| `POST /admin/realms/{realm}/organizations/{id}/members`             | `n/a`                                                               | [Organizations::addUser()](src/Resource/Organizations.php)    |
 
 ### [Realms Admin](https://www.keycloak.org/docs-api/26.0.0/rest-api/index.html#_realms_admin)
 
 | Endpoint                                       | Response                                              | API                                                    |
-| ---------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------ |
+|------------------------------------------------|-------------------------------------------------------|--------------------------------------------------------|
 | `POST /admin/realms`                           | [Realm](src/Representation/Realm.php)                 | [Realms::import()](src/Resource/Realms.php)            |
 | `GET /admin/realms`                            | [RealmCollection](src/Collection/RealmCollection.php) | [Realms::all()](src/Resource/Realms.php)               |
 | `PUT /admin/realms/{realm}`                    | [Realm](src/Representation/Realm.php)                 | [Realms::update()](src/Resource/Realms.php)            |
@@ -164,7 +164,7 @@ $myCustomRepresentation = $myCustomResource->myCustomEndpoint();
 ### [Users](https://www.keycloak.org/docs-api/26.0.0/rest-api/index.html#_users)
 
 | Endpoint                                                | Response                                                        | API                                                            |
-| ------------------------------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------- |
+|---------------------------------------------------------|-----------------------------------------------------------------|----------------------------------------------------------------|
 | `GET /admin/realms/{realm}/users`                       | [UserCollection](src/Collection/UserCollection.php)             | [Users::all()](src/Resource/Users.php)                         |
 | `POST /admin/realms/{realm}/users`                      | `n/a`                                                           | [Users::create()](src/Resource/Users.php)                      |
 | `GET /admin/realms/{realm}/users/{userId}`              | [User](src/Representation/User.php)                             | [Users::get()](src/Resource/Users.php)                         |
@@ -184,7 +184,7 @@ $myCustomRepresentation = $myCustomResource->myCustomEndpoint();
 ### [Roles](https://www.keycloak.org/docs-api/26.0.0/rest-api/index.html#_roles)
 
 | Endpoint                                        | Response                                            | API                                       |
-| ----------------------------------------------- | --------------------------------------------------- | ----------------------------------------- |
+|-------------------------------------------------|-----------------------------------------------------|-------------------------------------------|
 | `GET /admin/realms/{realm}/roles`               | [RoleCollection](src/Collection/RoleCollection.php) | [Roles::all()](src/Resource/Roles.php)    |
 | `GET /admin/realms/{realm}/roles/{roleName}`    | [Role](src/Representation/Role.php)                 | [Roles::get()](src/Resource/Roles.php)    |
 | `POST /admin/realms/{realm}/roles`              | `n/a`                                               | [Roles::create()](src/Resource/Roles.php) |
@@ -193,7 +193,7 @@ $myCustomRepresentation = $myCustomResource->myCustomEndpoint();
 ### [Root](https://www.keycloak.org/docs-api/26.0.0/rest-api/index.html#_root)
 
 | Endpoint                | Response                                        | API                                              |
-| ----------------------- | ----------------------------------------------- | ------------------------------------------------ |
+|-------------------------|-------------------------------------------------|--------------------------------------------------|
 | `GET /admin/serverinfo` | [ServerInfo](src/Representation/ServerInfo.php) | [ServerInfo::get()](src/Resource/ServerInfo.php) |
 
 ## Local development and testing

--- a/src/Http/Command.php
+++ b/src/Http/Command.php
@@ -17,8 +17,8 @@ class Command
         private readonly Method $method,
         /** @var array<string, string> */
         private readonly array $parameters = [],
-        /** @var Representation|Collection|array<mixed>|null */
-        private readonly Representation|Collection|array|null $payload = null,
+        /** @var Representation|Collection|array<mixed>|string|null */
+        private readonly Representation|Collection|array|string|null $payload = null,
         private readonly ?Criteria $criteria = null,
         private readonly ContentType $contentType = ContentType::JSON,
     ) {}
@@ -49,7 +49,7 @@ class Command
     /**
      * @return Representation|Collection|array<mixed>|null
      */
-    public function getPayload(): Representation|Collection|array|null
+    public function getPayload(): Representation|Collection|array|string|null
     {
         return $this->payload;
     }

--- a/src/Http/Command.php
+++ b/src/Http/Command.php
@@ -47,7 +47,7 @@ class Command
     }
 
     /**
-     * @return Representation|Collection|array<mixed>|null
+     * @return Representation|Collection|array<mixed>|string|null
      */
     public function getPayload(): Representation|Collection|array|string|null
     {

--- a/src/Http/CommandExecutor.php
+++ b/src/Http/CommandExecutor.php
@@ -6,8 +6,6 @@ namespace Fschmtt\Keycloak\Http;
 
 use Fschmtt\Keycloak\Serializer\Serializer;
 
-use function is_array;
-
 /**
  * @internal
  */
@@ -20,14 +18,16 @@ class CommandExecutor
 
     public function executeCommand(Command $command): void
     {
+        $payload = $command->getPayload();
+
         $options = match ($command->getContentType()) {
             ContentType::JSON => [
-                'body' => $this->serializer->serialize($command->getPayload()),
+                'body' => is_string($payload) ? $payload : $this->serializer->serialize($payload),
                 'headers' => [
                     'Content-Type' => $command->getContentType()->value,
                 ],
             ],
-            ContentType::FORM_PARAMS => ['form_params' => $command->getPayload()],
+            ContentType::FORM_PARAMS => ['form_params' => $payload],
         };
 
         $this->client->request(

--- a/src/Resource/Organizations.php
+++ b/src/Resource/Organizations.php
@@ -76,4 +76,17 @@ class Organizations extends Resource
             ),
         );
     }
+
+    public function addUser(string $realm, string $organizationId, string $userId): void
+    {
+        $this->commandExecutor->executeCommand(
+            new Command(
+                '/admin/realms/{realm}/organizations/{organizationId}/members',
+                Method::POST,
+                ['realm' => $realm, 'organizationId' => $organizationId],
+                payload: $userId,
+                contentType: ContentType::JSON,
+            ),
+        );
+    }
 }

--- a/tests/Unit/Http/CommandExecutorTest.php
+++ b/tests/Unit/Http/CommandExecutorTest.php
@@ -126,4 +126,31 @@ class CommandExecutorTest extends TestCase
         $executor = new CommandExecutor($client, new Serializer());
         $executor->executeCommand($command);
     }
+
+    public function testCallsClientWithUnserializedStringAsBodyIfPayloadIsString(): void
+    {
+        $command = new Command(
+            '/path/to/resource',
+            Method::PUT,
+            [],
+            $payload = 'string',
+        );
+
+        $client = $this->createMock(Client::class);
+        $client->expects(static::once())
+            ->method('request')
+            ->with(
+                Method::PUT->value,
+                '/path/to/resource',
+                [
+                    'body' => $payload,
+                    'headers' => [
+                        'Content-Type' => 'application/json',
+                    ],
+                ],
+            );
+
+        $executor = new CommandExecutor($client, new Serializer());
+        $executor->executeCommand($command);
+    }
 }

--- a/tests/Unit/Resource/OrganizationsTest.php
+++ b/tests/Unit/Resource/OrganizationsTest.php
@@ -164,4 +164,29 @@ class OrganizationsTest extends TestCase
 
         $organizations->inviteUser('test-realm', 'uuid', 'email', 'first name', 'last name');
     }
+
+    public function testAddUser(): void
+    {
+        $command = new Command(
+            '/admin/realms/{realm}/organizations/{organizationId}/members',
+            Method::POST,
+            [
+                'realm' => 'test-realm',
+                'organizationId' => 'organization-id',
+            ],
+            'user-id',
+        );
+
+        $commandExecutor = $this->createMock(CommandExecutor::class);
+        $commandExecutor->expects(static::once())
+            ->method('executeCommand')
+            ->with($command);
+
+        $organizations = new Organizations(
+            $commandExecutor,
+            $this->createMock(QueryExecutor::class),
+        );
+
+        $organizations->addUser('test-realm', 'organization-id', 'user-id');
+    }
 }


### PR DESCRIPTION
I'm trying to add a custom Resource for the endpoint:

`POST /admin/realms/{realm}/organizations/{org-id}/members`
https://www.keycloak.org/docs-api/latest/rest-api/index.html#OrganizationRepresentation

The body must be a string, the userId. Everything else results in a 400 Bad Request.