### PR TITLE
fix: class should not be internal

### DIFF
--- a/src/Http/Command.php
+++ b/src/Http/Command.php
@@ -7,9 +7,6 @@ namespace Fschmtt\Keycloak\Http;
 use Fschmtt\Keycloak\Collection\Collection;
 use Fschmtt\Keycloak\Representation\Representation;
 
-/**
- * @internal
- */
 class Command
 {
     public function __construct(

--- a/src/Http/Criteria.php
+++ b/src/Http/Criteria.php
@@ -7,9 +7,6 @@ namespace Fschmtt\Keycloak\Http;
 use DateTimeInterface;
 use Stringable;
 
-/**
- * @internal
- */
 class Criteria
 {
     /**

--- a/src/Http/Query.php
+++ b/src/Http/Query.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Fschmtt\Keycloak\Http;
 
-/**
- * @internal
- */
 class Query
 {
     public function __construct(


### PR DESCRIPTION
Similar to https://github.com/fschmtt/keycloak-rest-api-client-php/pull/156

Command/Query must be used (in accordance with the documentation) when doing [Customization](https://github.com/fschmtt/keycloak-rest-api-client-php?tab=readme-ov-file#customization), and therefore should not be internal.

Criteria is an optional parameter when calling the `->all(...)` method, so this should not be internal as well