### PR TITLE
Add user client role methods

### DIFF
--- a/src/Resource/Users.php
+++ b/src/Resource/Users.php
@@ -9,7 +9,6 @@ use Fschmtt\Keycloak\Collection\GroupCollection;
 use Fschmtt\Keycloak\Collection\RoleCollection;
 use Fschmtt\Keycloak\Collection\UserCollection;
 use Fschmtt\Keycloak\Http\Command;
-use Fschmtt\Keycloak\Http\ContentType;
 use Fschmtt\Keycloak\Http\Criteria;
 use Fschmtt\Keycloak\Http\Method;
 use Fschmtt\Keycloak\Http\Query;
@@ -199,6 +198,69 @@ class Users extends Resource
                 [
                     'realm' => $realm,
                     'userId' => $userId,
+                ],
+                $roles,
+            ),
+        );
+    }
+
+
+    public function retrieveClientRoles(string $realm, string $userId, string $clientUuid): RoleCollection
+    {
+        return $this->queryExecutor->executeQuery(
+            new Query(
+                '/admin/realms/{realm}/users/{userId}/role-mappings/clients/{clientUuid}',
+                RoleCollection::class,
+                [
+                    'realm' => $realm,
+                    'userId' => $userId,
+                    'clientUuid' => $clientUuid,
+                ],
+            ),
+        );
+    }
+
+    public function retrieveAvailableClientRoles(string $realm, string $userId, string $clientUuid): RoleCollection
+    {
+        return $this->queryExecutor->executeQuery(
+            new Query(
+                '/admin/realms/{realm}/users/{userId}/role-mappings/clients/{clientUuid}/available',
+                RoleCollection::class,
+                [
+                    'realm' => $realm,
+                    'userId' => $userId,
+                    'clientUuid' => $clientUuid,
+                ],
+            ),
+        );
+    }
+
+    public function addClientRoles(string $realm, string $userId, RoleCollection $roles, string $clientUuid): void
+    {
+        $this->commandExecutor->executeCommand(
+            new Command(
+                '/admin/realms/{realm}/users/{userId}/role-mappings/clients/{clientUuid}',
+                Method::POST,
+                [
+                    'realm' => $realm,
+                    'userId' => $userId,
+                    'clientUuid' => $clientUuid,
+                ],
+                $roles,
+            ),
+        );
+    }
+
+    public function removeClientRoles(string $realm, string $userId, RoleCollection $roles, string $clientUuid): void
+    {
+        $this->commandExecutor->executeCommand(
+            new Command(
+                '/admin/realms/{realm}/users/{userId}/role-mappings/clients/{clientUuid}',
+                Method::DELETE,
+                [
+                    'realm' => $realm,
+                    'userId' => $userId,
+                    'clientUuid' => $clientUuid,
                 ],
                 $roles,
             ),


### PR DESCRIPTION
This PR adds user client role mapping support to the Users resource.

List client roles for a user: Users::retrieveClientRoles($realm, $userId, $clientUuid)
List available client roles: Users::retrieveAvailableClientRoles($realm, $userId, $clientUuid)
Assign client roles to a user: Users::addClientRoles($realm, $userId, RoleCollection $roles, $clientUuid)
Remove client roles from a user: Users::removeClientRoles($realm, $userId, RoleCollection $roles, $clientUuid)

Used endpoints
GET /admin/realms/{realm}/users/{userId}/role-mappings/clients/{clientUuid}
GET /admin/realms/{realm}/users/{userId}/role-mappings/clients/{clientUuid}/available
POST /admin/realms/{realm}/users/{userId}/role-mappings/clients/{clientUuid}
DELETE /admin/realms/{realm}/users/{userId}/role-mappings/clients/{clientUuid}