### PR TITLE
feat(representation): add CpuInfo representation for Keycloak >= 26.3.0

### DIFF
--- a/src/Representation/CpuInfo.php
+++ b/src/Representation/CpuInfo.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fschmtt\Keycloak\Representation;
+
+use Fschmtt\Keycloak\Attribute\Since;
+
+/**
+ * @method int|null getProcessorCount()
+ * @method self withProcessorCount(?int $processorCount)
+ *
+ * @codeCoverageIgnore
+ */
+#[Since('26.3.0')]
+class CpuInfo extends Representation
+{
+    public function __construct(
+        protected ?int $processorCount = null,
+    ) {}
+}

--- a/src/Representation/ServerInfo.php
+++ b/src/Representation/ServerInfo.php
@@ -14,6 +14,7 @@ use Fschmtt\Keycloak\Type\Map;
  * @method Map|null getClientImporters()
  * @method Map|null getClientInstallations()
  * @method Map|null getComponentTypes()
+ * @method CpuInfo|null getCpuInfo()
  * @method CryptoInfo|null getCryptoInfo()
  * @method Map|null getEnums()
  * @method FeatureCollection|null getFeatures()
@@ -36,6 +37,8 @@ class ServerInfo extends Representation
         protected ?Map $clientImporters = null,
         protected ?Map $clientInstallations = null,
         protected ?Map $componentTypes = null,
+        #[Since('26.3.0')]
+        protected ?CpuInfo $cpuInfo = null,
         #[Since('20.0.0')]
         protected ?CryptoInfo $cryptoInfo = null,
         protected ?Map $enums = null,

--- a/tests/Integration/Resource/ServerInfoTest.php
+++ b/tests/Integration/Resource/ServerInfoTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fschmtt\Keycloak\Test\Integration\Resource;
 
+use Fschmtt\Keycloak\Representation\CpuInfo;
 use Fschmtt\Keycloak\Representation\ServerInfo;
 use Fschmtt\Keycloak\Test\Integration\IntegrationTestBehaviour;
 use PHPUnit\Framework\TestCase;
@@ -17,5 +18,17 @@ class ServerInfoTest extends TestCase
         $serverInfo = $this->getKeycloak()->serverInfo()->get();
 
         static::assertInstanceOf(ServerInfo::class, $serverInfo);
+    }
+
+    public function testCanGetCpuInfo(): void
+    {
+        $this->skipIfKeycloakVersionIsLessThan('26.3.0');
+
+        $serverInfo = $this->getKeycloak()->serverInfo()->get();
+        $cpuInfo = $serverInfo->getCpuInfo();
+
+        static::assertInstanceOf(CpuInfo::class, $cpuInfo);
+        static::assertIsInt($cpuInfo->getProcessorCount());
+        static::assertGreaterThan(0, $cpuInfo->getProcessorCount());
     }
 }


### PR DESCRIPTION
Support the `cpuInfo` field added to Keycloak's `/admin/serverinfo` response in 26.3.0, preventing PropertyDoesNotExistException on newer Keycloak versions. Older versions default to null. Added in keycloak with: https://github.com/keycloak/keycloak/commit/04191e0c7af881f7326c40359521a1dd928e03c5