### PR TITLE
Draft: feat: add 30s grace period for access token expiration

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -68,7 +68,7 @@ class Client
 
     public function isAuthorized(): bool
     {
-        return $this->tokenStorage->retrieveAccessToken()?->isExpired(new DateTime()) === false;
+        return $this->tokenStorage->retrieveAccessToken()?->isExpired((new DateTime())->add(new \DateInterval("PT30S"))) === false;
     }
 
     private function authorize(): void

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -68,7 +68,7 @@ class Client
 
     public function isAuthorized(): bool
     {
-        return $this->tokenStorage->retrieveAccessToken()?->isExpired((new DateTime())->add(new \DateInterval("PT30S"))) === false;
+        return $this->tokenStorage->retrieveAccessToken()?->isExpired((new DateTime())->add(new \DateInterval('PT30S'))) === false;
     }
 
     private function authorize(): void

--- a/tests/Unit/Http/ClientTest.php
+++ b/tests/Unit/Http/ClientTest.php
@@ -121,6 +121,58 @@ class ClientTest extends TestCase
         static::assertTrue($client->isAuthorized());
     }
 
+    public function testIsNotAuthorizedIfTokenExpiresWithinGracePeriod(): void
+    {
+        $accessToken = $this->generateToken((new DateTimeImmutable())->modify('+15 seconds'));
+
+        $tokenStorage = new InMemoryTokenStorage();
+        $tokenStorage->storeAccessToken($accessToken);
+
+        $client = new Client(
+            $this->keycloak,
+            $this->createMock(ClientInterface::class),
+            $tokenStorage,
+        );
+
+        static::assertFalse($client->isAuthorized());
+    }
+
+    public function testIsAuthorizedIfTokenExpiresAfterGracePeriod(): void
+    {
+        $accessToken = $this->generateToken((new DateTimeImmutable())->modify('+60 seconds'));
+
+        $tokenStorage = new InMemoryTokenStorage();
+        $tokenStorage->storeAccessToken($accessToken);
+
+        $client = new Client(
+            $this->keycloak,
+            $this->createMock(ClientInterface::class),
+            $tokenStorage,
+        );
+
+        static::assertTrue($client->isAuthorized());
+    }
+
+    public function testReAuthorizesWhenTokenIsWithinGracePeriod(): void
+    {
+        $expiringAccessToken = $this->generateToken((new DateTimeImmutable())->modify('+15 seconds'));
+        $refreshToken = $this->generateToken((new DateTimeImmutable())->modify('+1 hour'));
+
+        $tokenStorage = new InMemoryTokenStorage();
+        $tokenStorage->storeAccessToken($expiringAccessToken);
+        $tokenStorage->storeRefreshToken($refreshToken);
+
+        $guzzleClient = new GuzzleClient(['handler' => new MockHandler([
+            $this->generateTokenResponse(),
+            new Response(),
+        ])]);
+
+        $client = new Client($this->keycloak, $guzzleClient, $tokenStorage);
+        $client->request('GET', '/admin/realms');
+
+        static::assertNotEquals($expiringAccessToken->toString(), $tokenStorage->retrieveAccessToken()->toString());
+    }
+
     public function testAuthenticatesUsingConfiguredRealm(): void
     {
         $accessToken = $this->generateToken((new DateTimeImmutable())->modify('+1 hour'));


### PR DESCRIPTION
When running batch job i have run into timing problem, where clocks on servers were not 100% synced. From frontend development i know similar thing see this https://angular-auth-oidc-client.com/docs/documentation/configuration#renewtimebeforetokenexpiresinseconds.

In this draft PR i have only added 30 seconds in isAuthorized method, but i think this should be configurable somehow.
I can add it but i want to ask about the best place where to add it.